### PR TITLE
NP:3066 Revert commits regarding logging cognito info

### DIFF
--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/TriggerHandler.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/TriggerHandler.java
@@ -80,18 +80,9 @@ public class TriggerHandler implements RequestHandler<Map<String, Object>, Map<S
         UserDto user = getAndUpdateUserDetails(userDetails);
 
         updateUserDetailsInUserPool(userDetails, user);
-        waitForCognitoToSync();
 
         logger.info("handleRequest took {} ms", System.currentTimeMillis() - start);
         return input;
-    }
-
-    private void waitForCognitoToSync() {
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
     }
 
     @JacocoGenerated

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
@@ -5,8 +5,6 @@ import static no.unit.nva.cognito.TriggerHandler.EMPTY_STRING;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClientBuilder;
-import com.amazonaws.services.cognitoidp.model.AdminGetUserRequest;
-import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
 import com.amazonaws.services.cognitoidp.model.AdminUpdateUserAttributesRequest;
 import com.amazonaws.services.cognitoidp.model.AttributeType;
 import java.util.ArrayList;
@@ -52,10 +50,7 @@ public class UserPoolEntryUpdater {
 
         List<AttributeType> userAttributes = createUserAttributes(userDetails, user);
         AdminUpdateUserAttributesRequest request = createUpateRequestForUserEntryInCognito(userDetails, userAttributes);
-        logger.info("Updating User Attributes: " + request.toString());
-
         awsCognitoIdentityProvider.adminUpdateUserAttributes(request);
-        verifyThatCognitoHasUpdatedEntries(userDetails, userAttributes);
     }
 
     @JacocoGenerated
@@ -65,26 +60,6 @@ public class UserPoolEntryUpdater {
             .withRegion(Constants.AWS_REGION_VALUE.getName())
             .withCredentials(new DefaultAWSCredentialsProviderChain())
             .build();
-    }
-
-    private void verifyThatCognitoHasUpdatedEntries(UserDetails userDetails, List<AttributeType> insertedAttributes) {
-        AdminGetUserResult response = getCognitoUserDetails(userDetails);
-        List<AttributeType> actualAttributes = response.getUserAttributes();
-        insertedAttributes.removeAll(actualAttributes);
-        if (!insertedAttributes.isEmpty()) {
-            logger.warn(COGNITO_UPDATE_FAILURE_WARNING + toString(insertedAttributes));
-        }
-    }
-
-    private AdminGetUserResult getCognitoUserDetails(UserDetails userDetails) {
-        AdminGetUserRequest adminGetUserRequest = new AdminGetUserRequest()
-            .withUserPoolId(userDetails.getCognitoUserPool())
-            .withUsername(userDetails.getCognitoUserName());
-        return awsCognitoIdentityProvider.adminGetUser(adminGetUserRequest);
-    }
-
-    private String toString(List<AttributeType> desiredAttributes) {
-        return desiredAttributes.stream().map(AttributeType::toString).collect(Collectors.joining(","));
     }
 
     private AdminUpdateUserAttributesRequest createUpateRequestForUserEntryInCognito(UserDetails userDetails,

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
@@ -12,8 +12,6 @@ import com.amazonaws.services.cognitoidp.model.AttributeType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import no.unit.nva.cognito.Constants;
@@ -86,17 +84,11 @@ public class UserPoolEntryUpdater {
     }
 
     private String toString(List<AttributeType> desiredAttributes) {
-        return desiredAttributes.stream().map(this::attributeTypeToString)
-            .flatMap(Optional::stream)
-            .collect(Collectors.joining(","));
+        return desiredAttributes.stream().map(attributeType->toString(attributeType)).collect(Collectors.joining(","));
     }
 
-    private Optional<String> attributeTypeToString(AttributeType attributeType) {
-        if (Objects.nonNull(attributeType.getName()) && Objects.nonNull(attributeType.getValue())) {
-            return Optional.of(String.format("%s:%s", attributeType.getName(), attributeType.getValue()));
-        } else {
-            return Optional.empty();
-        }
+    private String toString(AttributeType attributeType) {
+        return String.format("%s:%s",attributeType.getName(),attributeType.getValue());
     }
 
     private AdminUpdateUserAttributesRequest createUpateRequestForUserEntryInCognito(UserDetails userDetails,

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
@@ -54,7 +54,7 @@ public class UserPoolEntryUpdater {
 
         List<AttributeType> userAttributes = createUserAttributes(userDetails, user);
         AdminUpdateUserAttributesRequest request = createUpateRequestForUserEntryInCognito(userDetails, userAttributes);
-        logger.info("AdminUpdateAttributesRequest:" + toString(request));
+        logger.info("Updating User Attributes: " + request.toString());
 
         awsCognitoIdentityProvider.adminUpdateUserAttributes(request);
         verifyThatCognitoHasUpdatedEntries(userDetails, userAttributes);
@@ -69,13 +69,8 @@ public class UserPoolEntryUpdater {
             .build();
     }
 
-    private String toString(AdminUpdateUserAttributesRequest request) {
-        return toString(request.getUserAttributes());
-    }
-
     private void verifyThatCognitoHasUpdatedEntries(UserDetails userDetails, List<AttributeType> insertedAttributes) {
         AdminGetUserResult response = getCognitoUserDetails(userDetails);
-        logger.info("AdminGetResult:"+toString(response.getUserAttributes()));
         List<AttributeType> actualAttributes = response.getUserAttributes();
         insertedAttributes.removeAll(actualAttributes);
         if (!insertedAttributes.isEmpty()) {

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
@@ -84,11 +84,7 @@ public class UserPoolEntryUpdater {
     }
 
     private String toString(List<AttributeType> desiredAttributes) {
-        return desiredAttributes.stream().map(attributeType->toString(attributeType)).collect(Collectors.joining(","));
-    }
-
-    private String toString(AttributeType attributeType) {
-        return String.format("%s:%s",attributeType.getName(),attributeType.getValue());
+        return desiredAttributes.stream().map(AttributeType::toString).collect(Collectors.joining(","));
     }
 
     private AdminUpdateUserAttributesRequest createUpateRequestForUserEntryInCognito(UserDetails userDetails,

--- a/cognito-pre-token-generation/src/test/java/no/unit/nva/cognito/TriggerHandlerTest.java
+++ b/cognito-pre-token-generation/src/test/java/no/unit/nva/cognito/TriggerHandlerTest.java
@@ -299,21 +299,6 @@ public class TriggerHandlerTest {
         assertEquals(requestEvent, responseEvent);
     }
 
-    @Test
-    public void handlerLogsMessageWithTheAttributeDiffernceWhenUserAttributesSavedAreNotTheSameAsDesired() {
-        mockCustomerApiWithExistingCustomer();
-        awsCognitoProvider = mockAwsIdentityProviderWhereAttributesAreNotSaved();
-        setupTriggerHandler();
-        Map<String, Object> requestEvent = createRequestEventWithInstitutionAndEduPersonAffiliation();
-        TestAppender logger = LogUtils.getTestingAppenderForRootLogger();
-
-        handler.handleRequest(requestEvent, mock(Context.class));
-        String logMessages = logger.getMessages();
-        assertThat(logMessages, containsString(COGNITO_UPDATE_FAILURE_WARNING));
-        String logMessagesAfterWarningPrefix =
-            logMessages.substring(logMessages.indexOf(COGNITO_UPDATE_FAILURE_WARNING));
-        assertThat(logMessagesAfterWarningPrefix, containsString(CUSTOM_APPLICATION_ROLES));
-    }
 
     private void setupTriggerHandler() {
         attributeTypesBuffer.set(null);
@@ -369,18 +354,6 @@ public class TriggerHandlerTest {
         return provider;
     }
 
-    private AWSCognitoIdentityProvider mockAwsIdentityProviderWhereAttributesAreNotSaved() {
-        AWSCognitoIdentityProvider provider = mock(AWSCognitoIdentityProvider.class);
-        when(provider.adminUpdateUserAttributes(any(AdminUpdateUserAttributesRequest.class)))
-            .thenAnswer(this::storeUserAttributes);
-        when(provider.adminGetUser(any(AdminGetUserRequest.class)))
-            .thenAnswer(this::returnEmptyUserAttributes);
-        return provider;
-    }
-
-    private AdminGetUserResult returnEmptyUserAttributes(InvocationOnMock invocationOnMock) {
-        return new AdminGetUserResult().withUserAttributes(Collections.emptyList());
-    }
 
     private AdminGetUserResult returnUserAttributes(InvocationOnMock invocationOnMock) {
         return new AdminGetUserResult().withUserAttributes(attributeTypesBuffer.get());


### PR DESCRIPTION
Remove all logging used for resolving the case NP-3066.  It has been verified that when we update the custom cognito fields and we read them immediately after, we receive the updated values. Therefore the problem lies in Cognito and there is nothing we can do in the PreTokenGenerationHandler code.