### PR TITLE
NP-2474: create logic for reliable converting of DTOs to DAOs and vive versa

### DIFF
--- a/buildSrc/src/main/groovy/nva.identity.service.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.identity.service.java-common-conventions.gradle
@@ -28,11 +28,11 @@ repositories {
 
 project.ext {
     nvaCommonsVersion = '1.12.0'
-    awsSdkVersion ="1.12.59"
-    jacksonVersion ="2.10.3"
+    awsSdkVersion = "1.12.59"
+    jacksonVersion = "2.10.3"
     xraySdkVersion = '2.9.1'
     DynamoDBLocalVersion = '1.15.0'
-    nvaTestUtilsVersion = '0.1.13'
+    nvaTestUtilsVersion = '0.1.24'
     zalandoProblemVersion = '0.25.0'
     awsLambdaCoreVersion = '1.2.1'
     jupiterVersion = "5.6.0"
@@ -78,6 +78,8 @@ dependencies {
     implementation group: 'com.amazonaws', name: 'aws-xray-recorder-sdk-aws-sdk'
     implementation group: 'com.amazonaws', name: 'aws-xray-recorder-sdk-aws-sdk-instrumentor'
 
+    testImplementation group: 'org.javers', name: 'javers-core', version: '6.2.5'
+    testImplementation group: 'com.github.javafaker', name: 'javafaker', version: '1.0.2'
     testImplementation group: 'com.github.BIBSYSDEV', name: 'nva-testutils', version: project.ext.nvaTestUtilsVersion
     testImplementation group: 'com.amazonaws', name: 'DynamoDBLocal', version: project.ext.DynamoDBLocalVersion
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
@@ -105,10 +107,12 @@ tasks.named('test') {
     testLogging {
         events('skipped', 'passed', 'failed')
     }
-    final Map<String, String> envVariables = new HashMap<>()
-    envVariables.put("ALLOWED_ORIGIN", "*")
-    environment(envVariables)
     finalizedBy jacocoTestReport
+}
+
+test {
+    environment "ID_NAMESPACE", "https://www.example.org"
+    environment "ALLOWED_ORIGIN", "*"
 }
 
 pmd {

--- a/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
+++ b/cognito-pre-token-generation/src/main/java/no/unit/nva/cognito/service/UserPoolEntryUpdater.java
@@ -62,8 +62,9 @@ public class UserPoolEntryUpdater {
             .build();
     }
 
-    private AdminUpdateUserAttributesRequest createUpateRequestForUserEntryInCognito(UserDetails userDetails,
-                                                                                     List<AttributeType> userAttributes) {
+    private AdminUpdateUserAttributesRequest createUpateRequestForUserEntryInCognito(
+        UserDetails userDetails,
+        List<AttributeType> userAttributes) {
         return new AdminUpdateUserAttributesRequest()
             .withUserPoolId(userDetails.getCognitoUserPool())
             .withUsername(userDetails.getCognitoUserName())

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDb.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDb.java
@@ -1,13 +1,15 @@
 package no.unit.nva.customer.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import no.unit.nva.customer.model.interfaces.Customer;
-import nva.commons.core.JacocoGenerated;
-
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import no.unit.nva.customer.model.interfaces.Customer;
+import nva.commons.core.JacocoGenerated;
 
 @JsonTypeName("Customer")
 public class CustomerDb implements Customer {
@@ -32,19 +34,24 @@ public class CustomerDb implements Customer {
     public CustomerDb() {
     }
 
-    private CustomerDb(Builder builder) {
-        setIdentifier(builder.identifier);
-        setCreatedDate(builder.createdDate);
-        setModifiedDate(builder.modifiedDate);
-        setName(builder.name);
-        setDisplayName(builder.displayName);
-        setShortName(builder.shortName);
-        setArchiveName(builder.archiveName);
-        setCname(builder.cname);
-        setInstitutionDns(builder.institutionDns);
-        setFeideOrganizationId(builder.feideOrganizationId);
-        setCristinId(builder.cristinId);
-        setVocabularySettings(builder.vocabularySettings);
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static CustomerDb fromCustomerDto(CustomerDto dto) {
+        return builder().withArchiveName(dto.getArchiveName())
+            .withCname(dto.getCname())
+            .withCreatedDate(dto.getCreatedDate())
+            .withCristinId(dto.getCristinId())
+            .withDisplayName(dto.getDisplayName())
+            .withIdentifier(dto.getIdentifier())
+            .withInstitutionDns(dto.getInstitutionDns())
+            .withShortName(dto.getShortName())
+            .withFeideOrganizationId(dto.getFeideOrganizationId())
+            .withModifiedDate(dto.getModifiedDate())
+            .withVocabularySettings(extractVocabularySettings(dto))
+            .withName(dto.getName())
+            .build();
     }
 
     @Override
@@ -159,6 +166,14 @@ public class CustomerDb implements Customer {
 
     @Override
     @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
+                            getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
+                            getCristinId(), getVocabularySettings());
+    }
+
+    @Override
+    @JacocoGenerated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -168,25 +183,17 @@ public class CustomerDb implements Customer {
         }
         CustomerDb that = (CustomerDb) o;
         return Objects.equals(getIdentifier(), that.getIdentifier())
-                && Objects.equals(getCreatedDate(), that.getCreatedDate())
-                && Objects.equals(getModifiedDate(), that.getModifiedDate())
-                && Objects.equals(getName(), that.getName())
-                && Objects.equals(getDisplayName(), that.getDisplayName())
-                && Objects.equals(getShortName(), that.getShortName())
-                && Objects.equals(getArchiveName(), that.getArchiveName())
-                && Objects.equals(getCname(), that.getCname())
-                && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
-                && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
-                && Objects.equals(getCristinId(), that.getCristinId())
-                && Objects.equals(getVocabularySettings(), that.getVocabularySettings());
-    }
-
-    @Override
-    @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
-                getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
-            getCristinId(), getVocabularySettings());
+               && Objects.equals(getCreatedDate(), that.getCreatedDate())
+               && Objects.equals(getModifiedDate(), that.getModifiedDate())
+               && Objects.equals(getName(), that.getName())
+               && Objects.equals(getDisplayName(), that.getDisplayName())
+               && Objects.equals(getShortName(), that.getShortName())
+               && Objects.equals(getArchiveName(), that.getArchiveName())
+               && Objects.equals(getCname(), that.getCname())
+               && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
+               && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
+               && Objects.equals(getCristinId(), that.getCristinId())
+               && Objects.equals(getVocabularySettings(), that.getVocabularySettings());
     }
 
     public Set<VocabularySettingDb> getVocabularySettings() {
@@ -197,86 +204,110 @@ public class CustomerDb implements Customer {
         this.vocabularySettings = vocabularySettings;
     }
 
+    public CustomerDto toCustomerDto() {
+        CustomerDto customerDto = CustomerDto.builder()
+            .withCname(this.getCname())
+            .withName(getName())
+            .withIdentifier(this.getIdentifier())
+            .withArchiveName(this.getArchiveName())
+            .withCreatedDate(this.getCreatedDate())
+            .withDisplayName(this.getDisplayName())
+            .withInstitutionDns(this.getInstitutionDns())
+            .withShortName(this.getShortName())
+            .withVocabularySettings(extractVocabularySettings())
+            .withModifiedDate(getModifiedDate())
+            .withFeideOrganizationId(getFeideOrganizationId())
+            .withCristinId(getCristinId())
+            .build();
+        return CustomerMapper.addContext(customerDto);
+    }
+
+    private static Set<VocabularySettingDb> extractVocabularySettings(CustomerDto dto) {
+        return Optional.ofNullable(dto.getVocabularySettings())
+            .stream()
+            .flatMap(Collection::stream)
+            .map(VocabularySettingDb::fromVocabularySettingsDto)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<VocabularySettingDto> extractVocabularySettings() {
+        return Optional.ofNullable(this.getVocabularySettings())
+            .stream()
+            .flatMap(Collection::stream)
+            .map(VocabularySettingDb::toVocabularySettingsDto)
+            .collect(Collectors.toSet());
+    }
 
     public static final class Builder {
-        private UUID identifier;
-        private Instant createdDate;
-        private Instant modifiedDate;
-        private String name;
-        private String displayName;
-        private String shortName;
-        private String archiveName;
-        private String cname;
-        private String institutionDns;
-        private String feideOrganizationId;
-        private String cristinId;
-        private Set<VocabularySettingDb> vocabularySettings;
+
+        private final CustomerDb customerDb;
 
         public Builder() {
+            customerDb = new CustomerDb();
         }
 
         public Builder withIdentifier(UUID identifier) {
-            this.identifier = identifier;
+            customerDb.setIdentifier(identifier);
             return this;
         }
 
         public Builder withCreatedDate(Instant createdDate) {
-            this.createdDate = createdDate;
+            customerDb.setCreatedDate(createdDate);
             return this;
         }
 
         public Builder withModifiedDate(Instant modifiedDate) {
-            this.modifiedDate = modifiedDate;
+            customerDb.setModifiedDate(modifiedDate);
             return this;
         }
 
         public Builder withName(String name) {
-            this.name = name;
+            customerDb.setName(name);
             return this;
         }
 
         public Builder withDisplayName(String displayName) {
-            this.displayName = displayName;
+            customerDb.setDisplayName(displayName);
             return this;
         }
 
         public Builder withShortName(String shortName) {
-            this.shortName = shortName;
+            customerDb.setShortName(shortName);
             return this;
         }
 
         public Builder withArchiveName(String archiveName) {
-            this.archiveName = archiveName;
+            customerDb.setArchiveName(archiveName);
             return this;
         }
 
         public Builder withCname(String cname) {
-            this.cname = cname;
+            customerDb.setCname(cname);
             return this;
         }
 
         public Builder withInstitutionDns(String institutionDns) {
-            this.institutionDns = institutionDns;
+            customerDb.setInstitutionDns(institutionDns);
             return this;
         }
 
         public Builder withFeideOrganizationId(String feideOrganizationId) {
-            this.feideOrganizationId = feideOrganizationId;
+            customerDb.setFeideOrganizationId(feideOrganizationId);
             return this;
         }
 
         public Builder withCristinId(String cristinId) {
-            this.cristinId = cristinId;
+            customerDb.setCristinId(cristinId);
             return this;
         }
 
         public Builder withVocabularySettings(Set<VocabularySettingDb> vocabularySettings) {
-            this.vocabularySettings = vocabularySettings;
+            customerDb.setVocabularySettings(vocabularySettings);
             return this;
         }
 
         public CustomerDb build() {
-            return new CustomerDb(this);
+            return customerDb;
         }
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDb.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDb.java
@@ -3,6 +3,7 @@ package no.unit.nva.customer.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +33,7 @@ public class CustomerDb implements Customer {
     private Set<VocabularySettingDb> vocabularySettings;
 
     public CustomerDb() {
+        vocabularySettings = Collections.emptySet();
     }
 
     public static Builder builder() {
@@ -172,6 +174,14 @@ public class CustomerDb implements Customer {
                             getCristinId(), getVocabularySettings());
     }
 
+    public Set<VocabularySettingDb> getVocabularySettings() {
+        return vocabularySettings;
+    }
+
+    public void setVocabularySettings(Set<VocabularySettingDb> vocabularySettings) {
+        this.vocabularySettings = Objects.nonNull(vocabularySettings) ? vocabularySettings : Collections.emptySet();
+    }
+
     @Override
     @JacocoGenerated
     public boolean equals(Object o) {
@@ -194,14 +204,6 @@ public class CustomerDb implements Customer {
                && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
                && Objects.equals(getCristinId(), that.getCristinId())
                && Objects.equals(getVocabularySettings(), that.getVocabularySettings());
-    }
-
-    public Set<VocabularySettingDb> getVocabularySettings() {
-        return vocabularySettings;
-    }
-
-    public void setVocabularySettings(Set<VocabularySettingDb> vocabularySettings) {
-        this.vocabularySettings = vocabularySettings;
     }
 
     public CustomerDto toCustomerDto() {

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -11,6 +12,7 @@ import no.unit.nva.customer.model.interfaces.Customer;
 import no.unit.nva.customer.model.interfaces.JsonLdSupport;
 import nva.commons.core.JacocoGenerated;
 
+@SuppressWarnings("PMD.ExcessivePublicCount")
 @JsonTypeName("Customer")
 public class CustomerDto implements Customer, JsonLdSupport {
 
@@ -31,7 +33,11 @@ public class CustomerDto implements Customer, JsonLdSupport {
     private URI context;
 
     public CustomerDto() {
+        vocabularySettings = Collections.emptySet();
+    }
 
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -42,6 +48,16 @@ public class CustomerDto implements Customer, JsonLdSupport {
     @Override
     public void setId(URI id) {
         this.id = id;
+    }
+
+    @Override
+    public URI getContext() {
+        return context;
+    }
+
+    @Override
+    public void setContext(URI context) {
+        this.context = context;
     }
 
     @Override
@@ -154,55 +170,146 @@ public class CustomerDto implements Customer, JsonLdSupport {
         this.cristinId = cristinId;
     }
 
-    @Override
-    public URI getContext() {
-        return context;
-    }
-
-    @Override
-    public void setContext(URI context) {
-        this.context = context;
-    }
-
-    @Override
-    @JacocoGenerated
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        CustomerDto that = (CustomerDto) o;
-        return Objects.equals(getId(), that.getId())
-            && Objects.equals(getIdentifier(), that.getIdentifier())
-            && Objects.equals(getCreatedDate(), that.getCreatedDate())
-            && Objects.equals(getModifiedDate(), that.getModifiedDate())
-            && Objects.equals(getName(), that.getName())
-            && Objects.equals(getDisplayName(), that.getDisplayName())
-            && Objects.equals(getShortName(), that.getShortName())
-            && Objects.equals(getArchiveName(), that.getArchiveName())
-            && Objects.equals(getCname(), that.getCname())
-            && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
-            && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
-            && Objects.equals(getCristinId(), that.getCristinId())
-            && Objects.equals(getVocabularySettings(), that.getVocabularySettings())
-            && Objects.equals(getContext(), that.getContext());
-    }
-
-    @Override
-    @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(getId(), getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
-            getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
-            getCristinId(), getVocabularySettings(), getContext());
-    }
-
     public Set<VocabularySettingDto> getVocabularySettings() {
         return vocabularySettings;
     }
 
     public void setVocabularySettings(Set<VocabularySettingDto> vocabularySettings) {
-        this.vocabularySettings = vocabularySettings;
+        this.vocabularySettings = Objects.nonNull(vocabularySettings) ? vocabularySettings : Collections.emptySet();
+    }
+
+    public Builder copy() {
+        return new Builder()
+            .withVocabularySettings(getVocabularySettings())
+            .withShortName(getShortName())
+            .withInstitutionDns(getInstitutionDns())
+            .withDisplayName(getDisplayName())
+            .withCreatedDate(getCreatedDate())
+            .withArchiveName(getArchiveName())
+            .withIdentifier(getIdentifier())
+            .withContext(getContext())
+            .withCname(getCname())
+            .withId(getId())
+            .withCristinId(getCristinId())
+            .withFeideOrganizationId(getFeideOrganizationId())
+            .withName(getName())
+            .withModifiedDate(getModifiedDate());
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
+                            getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
+                            getCristinId(), getVocabularySettings(), getContext());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CustomerDto)) {
+            return false;
+        }
+        CustomerDto that = (CustomerDto) o;
+        return Objects.equals(getId(), that.getId())
+               && Objects.equals(getIdentifier(), that.getIdentifier())
+               && Objects.equals(getCreatedDate(), that.getCreatedDate())
+               && Objects.equals(getModifiedDate(), that.getModifiedDate())
+               && Objects.equals(getName(), that.getName())
+               && Objects.equals(getDisplayName(), that.getDisplayName())
+               && Objects.equals(getShortName(), that.getShortName())
+               && Objects.equals(getArchiveName(), that.getArchiveName())
+               && Objects.equals(getCname(), that.getCname())
+               && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
+               && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
+               && Objects.equals(getCristinId(), that.getCristinId())
+               && Objects.equals(getVocabularySettings(), that.getVocabularySettings())
+               && Objects.equals(getContext(), that.getContext());
+    }
+
+    public static final class Builder {
+
+        private final CustomerDto customerDto;
+
+        private Builder() {
+            customerDto = new CustomerDto();
+        }
+
+        public Builder withId(URI id) {
+            customerDto.setId(id);
+            return this;
+        }
+
+        public Builder withIdentifier(UUID identifier) {
+            customerDto.setIdentifier(identifier);
+            return this;
+        }
+
+        public Builder withCreatedDate(Instant createdDate) {
+            customerDto.setCreatedDate(createdDate);
+            return this;
+        }
+
+        public Builder withModifiedDate(Instant modifiedDate) {
+            customerDto.setModifiedDate(modifiedDate);
+            return this;
+        }
+
+        public Builder withName(String name) {
+            customerDto.setName(name);
+            return this;
+        }
+
+        public Builder withDisplayName(String displayName) {
+            customerDto.setDisplayName(displayName);
+            return this;
+        }
+
+        public Builder withShortName(String shortName) {
+            customerDto.setShortName(shortName);
+            return this;
+        }
+
+        public Builder withArchiveName(String archiveName) {
+            customerDto.setArchiveName(archiveName);
+            return this;
+        }
+
+        public Builder withCname(String cname) {
+            customerDto.setCname(cname);
+            return this;
+        }
+
+        public Builder withInstitutionDns(String institutionDns) {
+            customerDto.setInstitutionDns(institutionDns);
+            return this;
+        }
+
+        public Builder withFeideOrganizationId(String feideOrganizationId) {
+            customerDto.setFeideOrganizationId(feideOrganizationId);
+            return this;
+        }
+
+        public Builder withCristinId(String cristinId) {
+            customerDto.setCristinId(cristinId);
+            return this;
+        }
+
+        public Builder withVocabularySettings(Set<VocabularySettingDto> vocabularySettings) {
+            customerDto.setVocabularySettings(vocabularySettings);
+            return this;
+        }
+
+        public Builder withContext(URI context) {
+            customerDto.setContext(context);
+            return this;
+        }
+
+        public CustomerDto build() {
+            return customerDto;
+        }
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerList.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerList.java
@@ -20,7 +20,7 @@ public class CustomerList {
 
     public CustomerList(List<CustomerDto> customers) {
         this.customers = customers;
-        this.context = CustomerMapper.context;
+        this.context = CustomerMapper.CONTEXT;
     }
 
     /**

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularySettingDb.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularySettingDb.java
@@ -1,9 +1,8 @@
 package no.unit.nva.customer.model;
 
-import no.unit.nva.customer.model.interfaces.VocabularySetting;
-
 import java.net.URI;
 import java.util.Objects;
+import no.unit.nva.customer.model.interfaces.VocabularySetting;
 
 public class VocabularySettingDb implements VocabularySetting {
 
@@ -52,6 +51,11 @@ public class VocabularySettingDb implements VocabularySetting {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(name, id, status);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -61,12 +65,17 @@ public class VocabularySettingDb implements VocabularySetting {
         }
         VocabularySettingDb that = (VocabularySettingDb) o;
         return Objects.equals(name, that.name)
-                && Objects.equals(id, that.id)
-                && status == that.status;
+               && Objects.equals(id, that.id)
+               && status == that.status;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, id, status);
+    public VocabularySettingDto toVocabularySettingsDto() {
+        return new VocabularySettingDto(this.getName(), this.getId(), this.getStatus());
+    }
+
+    public static VocabularySettingDb fromVocabularySettingsDto(VocabularySettingDto vocabularySettingDto) {
+        return new VocabularySettingDb(vocabularySettingDto.getName(),
+                                       vocabularySettingDto.getId(),
+                                       vocabularySettingDto.getStatus());
     }
 }

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDbTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDbTest.java
@@ -1,0 +1,126 @@
+package no.unit.nva.customer.model;
+
+import static no.unit.nva.customer.model.CustomerMapper.CONTEXT;
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.github.javafaker.Faker;
+import java.net.URI;
+import java.time.Instant;
+import java.time.Period;
+import java.util.Date;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.javers.core.Javers;
+import org.javers.core.JaversBuilder;
+import org.javers.core.diff.Diff;
+import org.junit.jupiter.api.Test;
+
+class CustomerDbTest {
+
+    public static final Faker FAKER = Faker.instance();
+    public static final Random RANDOM = new Random(System.currentTimeMillis());
+    public static final Javers JAVERS = JaversBuilder.javers().build();
+
+    @Test
+    public void toCustomerDtoReturnsDtoWithoutLossOfInformation() {
+        CustomerDb expected = crateSampleCustomerDb();
+        CustomerDto customerDto = expected.toCustomerDto();
+        CustomerDb actual = CustomerDb.fromCustomerDto(customerDto);
+        Diff diff = JAVERS.compare(expected, actual);
+        assertThat(customerDto, doesNotHaveEmptyValues());
+        assertThat(diff.prettyPrint(), diff.hasChanges(), is(false));
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    @Test
+    public void fromCustomerDbReturnsDbWithoutLossOfInformation() {
+        CustomerDto expected = crateSampleCustomerDto();
+        CustomerDb customerDb = CustomerDb.fromCustomerDto(expected);
+        CustomerDto actual = customerDb.toCustomerDto();
+        Diff diff = JAVERS.compare(expected, actual);
+        assertThat(customerDb, doesNotHaveEmptyValues());
+        assertThat(diff.prettyPrint(), diff.hasChanges(), is(false));
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    private CustomerDto crateSampleCustomerDto() {
+        UUID identifier = UUID.randomUUID();
+        URI id = CustomerMapper.toId(identifier);
+        CustomerDto customer = CustomerDto.builder()
+            .withName(randomString())
+            .withCristinId(randomString())
+            .withFeideOrganizationId(randomString())
+            .withModifiedDate(randomInstant())
+            .withIdentifier(identifier)
+            .withId(id)
+            .withCname(randomString())
+            .withContext(CONTEXT)
+            .withArchiveName(randomString())
+            .withShortName(randomString())
+            .withInstitutionDns(randomString())
+            .withDisplayName(randomString())
+            .withCreatedDate(randomInstant())
+            .withVocabularySettings(randomVocabularyDtoSettings())
+            .build();
+
+        assertThat(customer, doesNotHaveEmptyValues());
+        return customer;
+    }
+
+    private Set<VocabularySettingDto> randomVocabularyDtoSettings() {
+        return randomVocabularySettings()
+            .stream()
+            .map(VocabularySettingDb::toVocabularySettingsDto)
+            .collect(Collectors.toSet());
+    }
+
+    private CustomerDb crateSampleCustomerDb() {
+        CustomerDb customer = CustomerDb.builder()
+            .withIdentifier(randomIdentifier())
+            .withName(randomString())
+            .withModifiedDate(randomInstant())
+            .withShortName(randomString())
+            .withCristinId(randomString())
+            .withVocabularySettings(randomVocabularySettings())
+            .withInstitutionDns(randomString())
+            .withFeideOrganizationId(randomString())
+            .withDisplayName(randomString())
+            .withCreatedDate(randomInstant())
+            .withCname(randomString())
+            .withArchiveName(randomString())
+            .build();
+        assertThat(customer, doesNotHaveEmptyValues());
+        return customer;
+    }
+
+    private Set<VocabularySettingDb> randomVocabularySettings() {
+        VocabularySettingDb vocabulary = new VocabularySettingDb(randomString(), randomUri(),
+                                                                 randomElement(VocabularyStatus.values()));
+        return Set.of(vocabulary);
+    }
+
+    private <T> T randomElement(T[] values) {
+        return values[RANDOM.nextInt(values.length)];
+    }
+
+    private URI randomUri() {
+        return URI.create("https://www.example.com/" + FAKER.lorem().word() + FAKER.lorem().word());
+    }
+
+    private Instant randomInstant() {
+        return FAKER.date().between(Date.from(Instant.now().minus(Period.ofDays(10))),
+                                    Date.from(Instant.now())).toInstant();
+    }
+
+    private String randomString() {
+        return FAKER.lorem().sentence(2);
+    }
+
+    private UUID randomIdentifier() {
+        return UUID.randomUUID();
+    }
+}

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerTest.java
@@ -1,7 +1,6 @@
 package no.unit.nva.customer.model;
 
 import static java.lang.String.format;
-import static java.lang.String.valueOf;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
 import static no.unit.nva.hamcrest.DoesNotHaveNullOrEmptyFields.doesNotHaveNullOrEmptyFields;
@@ -10,10 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
@@ -70,9 +67,10 @@ public class CustomerTest {
     public void lookupUnknownVocabularyStatusThrowsIllegalArgumentException() {
         String value = "Unknown";
         IllegalArgumentException actual = assertThrows(IllegalArgumentException.class,
-            () -> VocabularyStatus.lookup(value));
-        String expectedMessage = format(VocabularyStatus.ERROR_MESSAGE_TEMPLATE, value, stream(VocabularyStatus.values())
-                        .map(VocabularyStatus::toString).collect(joining(VocabularyStatus.DELIMITER)));
+                                                       () -> VocabularyStatus.lookup(value));
+        String expectedMessage =
+            format(VocabularyStatus.ERROR_MESSAGE_TEMPLATE, value, stream(VocabularyStatus.values())
+                .map(VocabularyStatus::toString).collect(joining(VocabularyStatus.DELIMITER)));
 
         assertEquals(expectedMessage, actual.getMessage());
     }
@@ -83,7 +81,6 @@ public class CustomerTest {
         customerDb.getVocabularySettings().add(vocabularySetting());
 
         assertThat(customerDb.getVocabularySettings().size(), Matchers.is(Matchers.equalTo(1)));
-
     }
 
     private CustomerDb createCustomerDb() {
@@ -110,9 +107,9 @@ public class CustomerTest {
 
     private VocabularySettingDb vocabularySetting() {
         return new VocabularySettingDb(
-                "Vocabulary A",
-                URI.create("http://uri.to.vocabulary.a"),
-                VocabularyStatus.lookup("Default")
+            "Vocabulary A",
+            URI.create("http://uri.to.vocabulary.a"),
+            VocabularyStatus.lookup("Default")
         );
     }
 }


### PR DESCRIPTION
CustomerService exposes the DAOs to the rest of the platform and that makes things quite complicated.
At the same time CustomerMapper is not really a statefull class.

This is the first step of refactoring the customer service  where the final goal is the following:
1. The DAOs will contain the logic to be converted to DTOs and vice versa.
2. The DAOs will be as short-lived as possible, i.e., the customer service will only communicate with its clients through the DTOs. That is the handlers do not need to know about the DAOs.
3. The CustomerMapper can be a lot thinner.  

In this PR we create logic to map the DAOs to DTOs 

This  PR is part of the PR #47 

