### PR TITLE
 rename VocabulaySetting to Vocabulary

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
@@ -3,6 +3,7 @@ package no.unit.nva.customer.model;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,6 +20,7 @@ import nva.commons.core.JacocoGenerated;
     property = "type",
     defaultImpl = CustomerDao.class
 )
+@JsonTypeName("Customer")
 public class CustomerDao implements Customer<VocabularyDao> {
 
     public static final String IDENTIFIER = "identifier";

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
@@ -19,7 +19,7 @@ import nva.commons.core.JacocoGenerated;
     property = "type",
     defaultImpl = CustomerDao.class
 )
-public class CustomerDao implements Customer {
+public class CustomerDao implements Customer<VocabularyDao> {
 
     public static final String IDENTIFIER = "identifier";
     public static final String ORG_NUMBER = "feideOrganizationId";
@@ -36,10 +36,10 @@ public class CustomerDao implements Customer {
     private String institutionDns;
     private String feideOrganizationId;
     private String cristinId;
-    private Set<VocabularySettingDb> vocabularySettings;
+    private Set<VocabularyDao> vocabularies;
 
     public CustomerDao() {
-        vocabularySettings = Collections.emptySet();
+        vocabularies = Collections.emptySet();
     }
 
     public static Builder builder() {
@@ -177,15 +177,17 @@ public class CustomerDao implements Customer {
     public int hashCode() {
         return Objects.hash(getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
                             getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
-                            getCristinId(), getVocabularySettings());
+                            getCristinId(), getVocabularies());
     }
 
-    public Set<VocabularySettingDb> getVocabularySettings() {
-        return vocabularySettings;
+    @Override
+    public Set<VocabularyDao> getVocabularies() {
+        return vocabularies;
     }
 
-    public void setVocabularySettings(Set<VocabularySettingDb> vocabularySettings) {
-        this.vocabularySettings = Objects.nonNull(vocabularySettings) ? vocabularySettings : Collections.emptySet();
+    @Override
+    public void setVocabularies(Set<VocabularyDao> vocabularies) {
+        this.vocabularies = Objects.nonNull(vocabularies) ? vocabularies : Collections.emptySet();
     }
 
     @Override
@@ -209,7 +211,7 @@ public class CustomerDao implements Customer {
                && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
                && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
                && Objects.equals(getCristinId(), that.getCristinId())
-               && Objects.equals(getVocabularySettings(), that.getVocabularySettings());
+               && Objects.equals(getVocabularies(), that.getVocabularies());
     }
 
     public CustomerDto toCustomerDto() {
@@ -222,7 +224,7 @@ public class CustomerDao implements Customer {
             .withDisplayName(this.getDisplayName())
             .withInstitutionDns(this.getInstitutionDns())
             .withShortName(this.getShortName())
-            .withVocabularySettings(extractVocabularySettings())
+            .withVocabularies(extractVocabularySettings())
             .withModifiedDate(getModifiedDate())
             .withFeideOrganizationId(getFeideOrganizationId())
             .withCristinId(getCristinId())
@@ -230,19 +232,19 @@ public class CustomerDao implements Customer {
         return LinkedDataContextUtils.addContext(customerDto);
     }
 
-    private static Set<VocabularySettingDb> extractVocabularySettings(CustomerDto dto) {
-        return Optional.ofNullable(dto.getVocabularySettings())
+    private static Set<VocabularyDao> extractVocabularySettings(CustomerDto dto) {
+        return Optional.ofNullable(dto.getVocabularies())
             .stream()
             .flatMap(Collection::stream)
-            .map(VocabularySettingDb::fromVocabularySettingsDto)
+            .map(VocabularyDao::fromVocabularySettingsDto)
             .collect(Collectors.toSet());
     }
 
-    private Set<VocabularySettingDto> extractVocabularySettings() {
-        return Optional.ofNullable(this.getVocabularySettings())
+    private Set<VocabularyDto> extractVocabularySettings() {
+        return Optional.ofNullable(this.getVocabularies())
             .stream()
             .flatMap(Collection::stream)
-            .map(VocabularySettingDb::toVocabularySettingsDto)
+            .map(VocabularyDao::toVocabularySettingsDto)
             .collect(Collectors.toSet());
     }
 
@@ -309,8 +311,8 @@ public class CustomerDao implements Customer {
             return this;
         }
 
-        public Builder withVocabularySettings(Set<VocabularySettingDb> vocabularySettings) {
-            customerDb.setVocabularySettings(vocabularySettings);
+        public Builder withVocabularySettings(Set<VocabularyDao> vocabularySettings) {
+            customerDb.setVocabularies(vocabularySettings);
             return this;
         }
 

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
@@ -19,7 +19,7 @@ public class CustomerDto extends CustomerDtoWithoutContext implements Context {
 
     public CustomerDto() {
         super();
-        setVocabularySettings(Collections.emptySet());
+        setVocabularies(Collections.emptySet());
     }
 
     public CustomerDtoWithoutContext withoutContext() {
@@ -42,7 +42,7 @@ public class CustomerDto extends CustomerDtoWithoutContext implements Context {
 
     public Builder copy() {
         return new Builder()
-            .withVocabularySettings(getVocabularySettings())
+            .withVocabularies(getVocabularies())
             .withShortName(getShortName())
             .withInstitutionDns(getInstitutionDns())
             .withDisplayName(getDisplayName())
@@ -63,7 +63,7 @@ public class CustomerDto extends CustomerDtoWithoutContext implements Context {
     public int hashCode() {
         return Objects.hash(getId(), getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
                             getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
-                            getCristinId(), getVocabularySettings(), getContext());
+                            getCristinId(), getVocabularies(), getContext());
     }
 
     @JacocoGenerated
@@ -88,7 +88,7 @@ public class CustomerDto extends CustomerDtoWithoutContext implements Context {
                && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
                && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
                && Objects.equals(getCristinId(), that.getCristinId())
-               && Objects.equals(getVocabularySettings(), that.getVocabularySettings())
+               && Objects.equals(getVocabularies(), that.getVocabularies())
                && Objects.equals(getContext(), that.getContext());
     }
 
@@ -160,8 +160,8 @@ public class CustomerDto extends CustomerDtoWithoutContext implements Context {
             return this;
         }
 
-        public Builder withVocabularySettings(Set<VocabularySettingDto> vocabularySettings) {
-            customerDto.setVocabularySettings(vocabularySettings);
+        public Builder withVocabularies(Set<VocabularyDto> vocabularies) {
+            customerDto.setVocabularies(vocabularies);
             return this;
         }
 

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDtoWithoutContext.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDtoWithoutContext.java
@@ -10,7 +10,7 @@ import no.unit.nva.customer.model.interfaces.Resource;
 import nva.commons.core.JacocoGenerated;
 
 
-public class CustomerDtoWithoutContext implements Customer, Resource {
+public class CustomerDtoWithoutContext implements Customer<VocabularyDto>, Resource {
 
     private URI id;
     private UUID identifier;
@@ -24,7 +24,7 @@ public class CustomerDtoWithoutContext implements Customer, Resource {
     private String institutionDns;
     private String feideOrganizationId;
     private String cristinId;
-    private Set<VocabularySettingDto> vocabularySettings;
+    private Set<VocabularyDto> vocabularySettings;
 
     public CustomerDtoWithoutContext() {
 
@@ -172,7 +172,7 @@ public class CustomerDtoWithoutContext implements Customer, Resource {
                && Objects.equals(getInstitutionDns(), that.getInstitutionDns())
                && Objects.equals(getFeideOrganizationId(), that.getFeideOrganizationId())
                && Objects.equals(getCristinId(), that.getCristinId())
-               && Objects.equals(getVocabularySettings(), that.getVocabularySettings());
+               && Objects.equals(getVocabularies(), that.getVocabularies());
     }
 
     @Override
@@ -180,14 +180,16 @@ public class CustomerDtoWithoutContext implements Customer, Resource {
     public int hashCode() {
         return Objects.hash(getId(), getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
                             getShortName(), getArchiveName(), getCname(), getInstitutionDns(), getFeideOrganizationId(),
-                            getCristinId(), getVocabularySettings());
+                            getCristinId(), getVocabularies());
     }
 
-    public Set<VocabularySettingDto> getVocabularySettings() {
+    @Override
+    public Set<VocabularyDto> getVocabularies() {
         return vocabularySettings;
     }
 
-    public void setVocabularySettings(Set<VocabularySettingDto> vocabularySettings) {
+    @Override
+    public void setVocabularies(Set<VocabularyDto> vocabularySettings) {
         this.vocabularySettings = vocabularySettings;
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularyDao.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularyDao.java
@@ -2,19 +2,19 @@ package no.unit.nva.customer.model;
 
 import java.net.URI;
 import java.util.Objects;
-import no.unit.nva.customer.model.interfaces.VocabularySetting;
+import no.unit.nva.customer.model.interfaces.Vocabulary;
 
 
-public class VocabularySettingDb implements VocabularySetting {
+public class VocabularyDao implements Vocabulary {
 
     private String name;
     private URI id;
     private VocabularyStatus status;
 
-    public VocabularySettingDb() {
+    public VocabularyDao() {
     }
 
-    public VocabularySettingDb(String name, URI id, VocabularyStatus status) {
+    public VocabularyDao(String name, URI id, VocabularyStatus status) {
         this();
         this.name = name;
         this.id = id;
@@ -64,19 +64,19 @@ public class VocabularySettingDb implements VocabularySetting {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        VocabularySettingDb that = (VocabularySettingDb) o;
+        VocabularyDao that = (VocabularyDao) o;
         return Objects.equals(name, that.name)
                && Objects.equals(id, that.id)
                && status == that.status;
     }
 
-    public VocabularySettingDto toVocabularySettingsDto() {
-        return new VocabularySettingDto(this.getName(), this.getId(), this.getStatus());
+    public VocabularyDto toVocabularySettingsDto() {
+        return new VocabularyDto(this.getName(), this.getId(), this.getStatus());
     }
 
-    public static VocabularySettingDb fromVocabularySettingsDto(VocabularySettingDto vocabularySettingDto) {
-        return new VocabularySettingDb(vocabularySettingDto.getName(),
-                                       vocabularySettingDto.getId(),
-                                       vocabularySettingDto.getStatus());
+    public static VocabularyDao fromVocabularySettingsDto(VocabularyDto vocabularySettingDto) {
+        return new VocabularyDao(vocabularySettingDto.getName(),
+                                 vocabularySettingDto.getId(),
+                                 vocabularySettingDto.getStatus());
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularyDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/VocabularyDto.java
@@ -2,20 +2,20 @@ package no.unit.nva.customer.model;
 
 import java.net.URI;
 import java.util.Objects;
-import no.unit.nva.customer.model.interfaces.VocabularySetting;
+import no.unit.nva.customer.model.interfaces.Vocabulary;
 import nva.commons.core.JacocoGenerated;
 
-public class VocabularySettingDto implements VocabularySetting {
+public class VocabularyDto implements Vocabulary {
 
     private String name;
     private URI id;
     private VocabularyStatus status;
 
-    public VocabularySettingDto() {
+    public VocabularyDto() {
     }
 
     @JacocoGenerated
-    public VocabularySettingDto(String name, URI id, VocabularyStatus status) {
+    public VocabularyDto(String name, URI id, VocabularyStatus status) {
         this();
         this.name = name;
         this.id = id;
@@ -70,10 +70,10 @@ public class VocabularySettingDto implements VocabularySetting {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof VocabularySettingDto)) {
+        if (!(o instanceof VocabularyDto)) {
             return false;
         }
-        VocabularySettingDto that = (VocabularySettingDto) o;
+        VocabularyDto that = (VocabularyDto) o;
         return Objects.equals(getName(), that.getName())
                && Objects.equals(getId(), that.getId())
                && getStatus() == that.getStatus();

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/Customer.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/Customer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.time.Instant;
+import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -12,7 +13,7 @@ import java.util.UUID;
     include = As.PROPERTY,
     property = "type")
 @JsonTypeName("Customer")
-public interface Customer {
+public interface Customer<T extends Vocabulary> {
 
     UUID getIdentifier();
 
@@ -58,4 +59,7 @@ public interface Customer {
 
     void setCristinId(String cristinId);
 
+    Set<T> getVocabularies();
+
+    void setVocabularies(Set<T> vocabularies);
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/Vocabulary.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/Vocabulary.java
@@ -11,8 +11,8 @@ import no.unit.nva.customer.model.VocabularyStatus;
     use = JsonTypeInfo.Id.NAME,
     include = As.PROPERTY,
     property = "type")
-@JsonTypeName("VocabularySetting")
-public interface VocabularySetting {
+@JsonTypeName("Vocabulary")
+public interface Vocabulary {
 
     String getName();
 

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/VocabularyList.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/interfaces/VocabularyList.java
@@ -12,7 +12,7 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Set;
 import no.unit.nva.customer.model.LinkedDataContextUtils;
-import no.unit.nva.customer.model.VocabularySettingDto;
+import no.unit.nva.customer.model.VocabularyDto;
 import nva.commons.core.JacocoGenerated;
 
 @SuppressWarnings("PMD.ExcessivePublicCount")
@@ -20,20 +20,20 @@ import nva.commons.core.JacocoGenerated;
     use = JsonTypeInfo.Id.NAME,
     include = As.PROPERTY,
     property = "type")
-@JsonTypeName("VocabularySettingsList")
-public class VocabularySettingsList implements Context {
+@JsonTypeName("VocabularyList")
+public class VocabularyList implements Context {
 
-    public static final String VOCABULARY_SETTINGS = "vocabularySettings";
+    public static final String VOCABULARY_SETTINGS = "vocabularies";
     @JsonProperty(VOCABULARY_SETTINGS)
-    private final Set<VocabularySettingDto> vocabularySettings;
+    private final Set<VocabularyDto> vocabularies;
 
     @JsonCreator
-    public <E> VocabularySettingsList(@JsonProperty(VOCABULARY_SETTINGS) Set<VocabularySettingDto> vocabularySettings) {
-        this.vocabularySettings = vocabularySettings;
+    public <E> VocabularyList(@JsonProperty(VOCABULARY_SETTINGS) Set<VocabularyDto> vocabularySettings) {
+        this.vocabularies = vocabularySettings;
     }
 
-    public Set<VocabularySettingDto> getVocabularySettings() {
-        return vocabularySettings;
+    public Set<VocabularyDto> getVocabularies() {
+        return vocabularies;
     }
 
     @JsonProperty(LinkedDataContextUtils.LINKED_DATA_ID)
@@ -56,7 +56,7 @@ public class VocabularySettingsList implements Context {
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(getVocabularySettings());
+        return Objects.hash(getVocabularies());
     }
 
     @JacocoGenerated
@@ -65,10 +65,10 @@ public class VocabularySettingsList implements Context {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof VocabularySettingsList)) {
+        if (!(o instanceof VocabularyList)) {
             return false;
         }
-        VocabularySettingsList that = (VocabularySettingsList) o;
-        return Objects.equals(getVocabularySettings(), that.getVocabularySettings());
+        VocabularyList that = (VocabularyList) o;
+        return Objects.equals(getVocabularies(), that.getVocabularies());
     }
 }

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDbTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDbTest.java
@@ -64,17 +64,17 @@ class CustomerDbTest {
             .withInstitutionDns(randomString())
             .withDisplayName(randomString())
             .withCreatedDate(randomInstant())
-            .withVocabularySettings(randomVocabularyDtoSettings())
+            .withVocabularies(randomVocabularyDtoSettings())
             .build();
 
         assertThat(customer, doesNotHaveEmptyValues());
         return customer;
     }
 
-    private Set<VocabularySettingDto> randomVocabularyDtoSettings() {
+    private Set<VocabularyDto> randomVocabularyDtoSettings() {
         return randomVocabularySettings()
             .stream()
-            .map(VocabularySettingDb::toVocabularySettingsDto)
+            .map(VocabularyDao::toVocabularySettingsDto)
             .collect(Collectors.toSet());
     }
 
@@ -97,9 +97,9 @@ class CustomerDbTest {
         return customer;
     }
 
-    private Set<VocabularySettingDb> randomVocabularySettings() {
-        VocabularySettingDb vocabulary = new VocabularySettingDb(randomString(), randomUri(),
-                                                                 randomElement(VocabularyStatus.values()));
+    private Set<VocabularyDao> randomVocabularySettings() {
+        VocabularyDao vocabulary = new VocabularyDao(randomString(), randomUri(),
+                                                     randomElement(VocabularyStatus.values()));
         return Set.of(vocabulary);
     }
 

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerTest.java
@@ -71,15 +71,15 @@ public class CustomerTest {
     @Test
     public void vocacularySettingsDoesNotContainDuplicates() {
         CustomerDao customerDb = createCustomerDb();
-        customerDb.getVocabularySettings().add(vocabularySetting());
+        customerDb.getVocabularies().add(vocabularySetting());
 
-        assertThat(customerDb.getVocabularySettings().size(), Matchers.is(Matchers.equalTo(1)));
+        assertThat(customerDb.getVocabularies().size(), Matchers.is(Matchers.equalTo(1)));
     }
 
     private CustomerDao createCustomerDb() {
         Instant now = Instant.now();
 
-        Set<VocabularySettingDb> vocabularySettings = new HashSet<>();
+        Set<VocabularyDao> vocabularySettings = new HashSet<>();
         vocabularySettings.add(vocabularySetting());
 
         return new CustomerDao.Builder()
@@ -98,8 +98,8 @@ public class CustomerTest {
             .build();
     }
 
-    private VocabularySettingDb vocabularySetting() {
-        return new VocabularySettingDb(
+    private VocabularyDao vocabularySetting() {
+        return new VocabularyDao(
             "Vocabulary A",
             URI.create("http://uri.to.vocabulary.a"),
             VocabularyStatus.lookup("Default")

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/interfaces/VocabularySettingsListTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/interfaces/VocabularySettingsListTest.java
@@ -17,19 +17,19 @@ class VocabularySettingsListTest {
 
     @Test
     void serializationReturnsObjectWithContextEqualToCustomersContext() throws JsonProcessingException {
-        VocabularySettingsList list = new VocabularySettingsList(Collections.emptySet());
+        VocabularyList list = new VocabularyList(Collections.emptySet());
         ObjectNode json = toJson(list);
         assertThat(json.get(LINKED_DATA_CONTEXT).textValue(), is(equalTo(LINKED_DATA_CONTEXT_VALUE.toString())));
     }
 
     @Test
     void serializationReturnsObjectWithIdEqualToTheNamespaceOfCustomers() throws JsonProcessingException {
-        VocabularySettingsList list = new VocabularySettingsList(Collections.emptySet());
+        VocabularyList list = new VocabularyList(Collections.emptySet());
         ObjectNode json = toJson(list);
         assertThat(json.get(LINKED_DATA_ID).textValue(), is(equalTo(ID_NAMESPACE.toString())));
     }
 
-    private ObjectNode toJson(VocabularySettingsList list) throws JsonProcessingException {
+    private ObjectNode toJson(VocabularyList list) throws JsonProcessingException {
         String jsonString = JsonUtils.objectMapperWithEmpty.writeValueAsString(list);
         return (ObjectNode) JsonUtils.objectMapperWithEmpty.readTree(jsonString);
     }

--- a/customer/src/main/java/no/unit/nva/customer/WriteControlledVocabularyHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/WriteControlledVocabularyHandler.java
@@ -3,31 +3,31 @@ package no.unit.nva.customer;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.UUID;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.CustomerService;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 
 public abstract class WriteControlledVocabularyHandler
-    extends ControlledVocabularyHandler<VocabularySettingsList, VocabularySettingsList> {
+    extends ControlledVocabularyHandler<VocabularyList, VocabularyList> {
 
     public WriteControlledVocabularyHandler(CustomerService customerService) {
-        super(VocabularySettingsList.class, customerService);
+        super(VocabularyList.class, customerService);
     }
 
 
-    protected abstract CustomerDto updateVocabularySettings(VocabularySettingsList input, CustomerDto customer)
+    protected abstract CustomerDto updateVocabularySettings(VocabularyList input, CustomerDto customer)
         throws ApiGatewayException;
 
     @Override
-    protected final VocabularySettingsList processInput(VocabularySettingsList input,
-                                                  RequestInfo requestInfo,
-                                                  Context context) throws ApiGatewayException {
+    protected final VocabularyList processInput(VocabularyList input,
+                                                RequestInfo requestInfo,
+                                                Context context) throws ApiGatewayException {
         UUID identifier = extractIdentifier(requestInfo);
         CustomerDto customer = customerService.getCustomer(identifier);
         customer = updateVocabularySettings(input, customer);
         CustomerDto updatedCustomer = customerService.updateCustomer(identifier, customer);
-        return new VocabularySettingsList(updatedCustomer.getVocabularySettings());
+        return new VocabularyList(updatedCustomer.getVocabularies());
     }
 
 }

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateControlledVocabularyHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateControlledVocabularyHandler.java
@@ -4,7 +4,7 @@ import static no.unit.nva.customer.Constants.defaultCustomerService;
 import java.net.HttpURLConnection;
 import no.unit.nva.customer.WriteControlledVocabularyHandler;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.CustomerService;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.ConflictException;
@@ -24,16 +24,16 @@ public class CreateControlledVocabularyHandler extends WriteControlledVocabulary
     }
 
     @Override
-    protected CustomerDto updateVocabularySettings(VocabularySettingsList input, CustomerDto customer)
+    protected CustomerDto updateVocabularySettings(VocabularyList input, CustomerDto customer)
         throws ApiGatewayException {
-        if (customer.getVocabularySettings().isEmpty()) {
-            return customer.copy().withVocabularySettings(input.getVocabularySettings()).build();
+        if (customer.getVocabularies().isEmpty()) {
+            return customer.copy().withVocabularies(input.getVocabularies()).build();
         }
         throw new ConflictException(CUSTOMER_SETTINGS_EXIST_ERROR);
     }
 
     @Override
-    protected Integer getSuccessStatusCode(VocabularySettingsList input, VocabularySettingsList output) {
+    protected Integer getSuccessStatusCode(VocabularyList input, VocabularyList output) {
         return HttpURLConnection.HTTP_CREATED;
     }
 }

--- a/customer/src/main/java/no/unit/nva/customer/get/GetControlledVocabularyHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/get/GetControlledVocabularyHandler.java
@@ -6,14 +6,14 @@ import java.net.HttpURLConnection;
 import java.util.Set;
 import java.util.UUID;
 import no.unit.nva.customer.ControlledVocabularyHandler;
-import no.unit.nva.customer.model.VocabularySettingDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.VocabularyDto;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.CustomerService;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.JacocoGenerated;
 
-public class GetControlledVocabularyHandler extends ControlledVocabularyHandler<Void, VocabularySettingsList> {
+public class GetControlledVocabularyHandler extends ControlledVocabularyHandler<Void, VocabularyList> {
 
     @JacocoGenerated
     public GetControlledVocabularyHandler() {
@@ -25,16 +25,16 @@ public class GetControlledVocabularyHandler extends ControlledVocabularyHandler<
     }
 
     @Override
-    protected VocabularySettingsList processInput(Void input, RequestInfo requestInfo, Context context)
+    protected VocabularyList processInput(Void input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
         UUID identifier = UUID.fromString(requestInfo.getPathParameter(IDENTIFIER_PATH_PARAMETER));
-        Set<VocabularySettingDto> vocabularySettings =
-            customerService.getCustomer(identifier).getVocabularySettings();
-        return new VocabularySettingsList(vocabularySettings);
+        Set<VocabularyDto> vocabularySettings =
+            customerService.getCustomer(identifier).getVocabularies();
+        return new VocabularyList(vocabularySettings);
     }
 
     @Override
-    protected Integer getSuccessStatusCode(Void input, VocabularySettingsList output) {
+    protected Integer getSuccessStatusCode(Void input, VocabularyList output) {
         return HttpURLConnection.HTTP_OK;
     }
 }

--- a/customer/src/main/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandler.java
@@ -3,7 +3,7 @@ package no.unit.nva.customer.update;
 import java.net.HttpURLConnection;
 import no.unit.nva.customer.create.CreateControlledVocabularyHandler;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -24,16 +24,16 @@ public class UpdateControlledVocabularyHandler extends CreateControlledVocabular
     }
 
     @Override
-    protected CustomerDto updateVocabularySettings(VocabularySettingsList input, CustomerDto customer)
+    protected CustomerDto updateVocabularySettings(VocabularyList input, CustomerDto customer)
         throws ApiGatewayException {
-        if (!customer.getVocabularySettings().isEmpty()) {
-            return customer.copy().withVocabularySettings(input.getVocabularySettings()).build();
+        if (!customer.getVocabularies().isEmpty()) {
+            return customer.copy().withVocabularies(input.getVocabularies()).build();
         }
         throw new NotFoundException(VOCABULARY_SETTINGS_NOT_DEFINED_ERROR);
     }
 
     @Override
-    protected Integer getSuccessStatusCode(VocabularySettingsList input, VocabularySettingsList output) {
+    protected Integer getSuccessStatusCode(VocabularyList input, VocabularyList output) {
         return HttpURLConnection.HTTP_ACCEPTED;
     }
 }

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateControlledVocabularyTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateControlledVocabularyTest.java
@@ -15,9 +15,8 @@ import java.util.Set;
 import java.util.UUID;
 import no.unit.nva.customer.ControlledVocabularyHandler;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.CustomerDtoWithoutContext;
-import no.unit.nva.customer.model.VocabularySettingDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.VocabularyDto;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.testing.CreateUpdateControlledVocabularySettingsTests;
 import no.unit.nva.customer.testing.CustomerDataGenerator;
 import nva.commons.apigateway.GatewayResponse;
@@ -30,33 +29,33 @@ public class CreateControlledVocabularyTest extends CreateUpdateControlledVocabu
     @Test
     public void handleRequestReturnsCreatedWhenCreatingVocabularyForExistingCustomer() throws IOException {
         sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
     }
 
     @Test
     public void handleRequestReturnsCreatedVocabularyListWhenCreatingVocabularyForExistingCustomer()
         throws IOException {
-        VocabularySettingsList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
-        VocabularySettingsList body = response.getBodyObject(VocabularySettingsList.class);
+        VocabularyList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
+        VocabularyList body = response.getBodyObject(VocabularyList.class);
         assertThat(body, is(equalTo(expectedBody)));
     }
 
     @Test
     public void handleRequestSavesVocabularySettingsToDatabaseWhenCreatingSettingsForExistingCustomer()
         throws IOException, ApiGatewayException {
-        VocabularySettingsList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
-        Set<VocabularySettingDto> savedVocabularySettings =
-            customerService.getCustomer(existingIdentifier()).getVocabularySettings();
-        assertThat(savedVocabularySettings, is(equalTo(expectedBody.getVocabularySettings())));
+        VocabularyList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
+        Set<VocabularyDto> savedVocabularySettings =
+            customerService.getCustomer(existingIdentifier()).getVocabularies();
+        assertThat(savedVocabularySettings, is(equalTo(expectedBody.getVocabularies())));
     }
 
     @Test
     public void handleRequestReturnsNotFoundWhenTryingToSaveSettingsForNonExistingCustomer()
         throws IOException {
         sendRequestAcceptingJsonLd(UUID.randomUUID());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
     }
 
@@ -67,21 +66,21 @@ public class CreateControlledVocabularyTest extends CreateUpdateControlledVocabu
         InputStream request = addVocabularyForCustomer(existingIdentifier(), invalidBody,
                                                        MediaTypes.APPLICATION_JSON_LD);
         handler.handleRequest(request, outputStream, CONTEXT);
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonLdWhenAcceptHeaderIsJsonLd() throws IOException {
         sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(responseContentType(response), is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString())));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonWhenAcceptHeaderIsJson() throws IOException {
         sendRequest(existingIdentifier(), MediaType.JSON_UTF_8);
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         String content = responseContentType(response);
         assertThat(content, is(equalTo(MediaType.JSON_UTF_8.toString())));
     }
@@ -104,7 +103,7 @@ public class CreateControlledVocabularyTest extends CreateUpdateControlledVocabu
         sendRequestAcceptingJsonLd(existingIdentifier());
         outputStream = new ByteArrayOutputStream();
         sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
     }
 
@@ -116,7 +115,7 @@ public class CreateControlledVocabularyTest extends CreateUpdateControlledVocabu
     @Override
     protected CustomerDto createExistingCustomer() {
         return CustomerDataGenerator.crateSampleCustomerDto().copy()
-            .withVocabularySettings(Collections.emptySet())
+            .withVocabularies(Collections.emptySet())
             .build();
     }
 }

--- a/customer/src/test/java/no/unit/nva/customer/get/GetControlledVocabularyHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/get/GetControlledVocabularyHandlerTest.java
@@ -23,8 +23,8 @@ import java.util.Set;
 import java.util.UUID;
 import no.unit.nva.customer.ObjectMapperConfig;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.VocabularySettingDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.VocabularyDto;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import no.unit.nva.customer.testing.CustomerDataGenerator;
 import no.unit.nva.customer.testing.CustomerDynamoDBLocal;
@@ -57,13 +57,13 @@ public class GetControlledVocabularyHandlerTest extends CustomerDynamoDBLocal {
 
     @Test
     public void handleRequestReturnsOkWhenARequestWithAnExistingIdentifierIsSubmitted() throws IOException {
-        GatewayResponse<VocabularySettingsList> response = sendGetRequest(getExistingCustomerIdentifier());
+        GatewayResponse<VocabularyList> response = sendGetRequest(getExistingCustomerIdentifier());
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
     }
 
     @Test
     public void handleRequestReturnsNotFoundWhenARequestWithANonExistingIdentifierIsSubmitted() throws IOException {
-        GatewayResponse<VocabularySettingsList> response = sendGetRequest(randomCustomerIdentifier());
+        GatewayResponse<VocabularyList> response = sendGetRequest(randomCustomerIdentifier());
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
     }
 
@@ -89,22 +89,22 @@ public class GetControlledVocabularyHandlerTest extends CustomerDynamoDBLocal {
     @Test
     public void handleRequestReturnsControlledVocabulariesOfSpecifiedCustomerWhenCustomerIdIsValid()
         throws IOException {
-        GatewayResponse<VocabularySettingsList> response = sendGetRequest(getExistingCustomerIdentifier());
-        VocabularySettingsList body = response.getBodyObject(VocabularySettingsList.class);
-        Set<VocabularySettingDto> actualVocabularySettings = body.getVocabularySettings();
-        assertThat(actualVocabularySettings, is(equalTo(existingCustomer.getVocabularySettings())));
+        GatewayResponse<VocabularyList> response = sendGetRequest(getExistingCustomerIdentifier());
+        VocabularyList body = response.getBodyObject(VocabularyList.class);
+        Set<VocabularyDto> actualVocabularySettings = body.getVocabularies();
+        assertThat(actualVocabularySettings, is(equalTo(existingCustomer.getVocabularies())));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonLdWhenAcceptHeaderIsJsonLd() throws IOException {
-        GatewayResponse<VocabularySettingsList> response = sendGetRequest(getExistingCustomerIdentifier());
+        GatewayResponse<VocabularyList> response = sendGetRequest(getExistingCustomerIdentifier());
         String content = response.getHeaders().get(HttpHeaders.CONTENT_TYPE);
         assertThat(content, is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString())));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonWhenAcceptHeaderIsJson() throws IOException {
-        GatewayResponse<VocabularySettingsList> response =
+        GatewayResponse<VocabularyList> response =
             sendRequestAcceptingJson(getExistingCustomerIdentifier());
         String content = response.getHeaders().get(HttpHeaders.CONTENT_TYPE);
         assertThat(content, is(equalTo(MediaType.JSON_UTF_8.toString())));

--- a/customer/src/test/java/no/unit/nva/customer/testing/CreateUpdateControlledVocabularySettingsTests.java
+++ b/customer/src/test/java/no/unit/nva/customer/testing/CreateUpdateControlledVocabularySettingsTests.java
@@ -18,8 +18,7 @@ import java.util.UUID;
 import no.unit.nva.customer.ControlledVocabularyHandler;
 import no.unit.nva.customer.get.GetControlledVocabularyHandler;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.CustomerDtoWithoutContext;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.GatewayResponse;
@@ -53,18 +52,18 @@ public abstract class CreateUpdateControlledVocabularySettingsTests extends Cust
 
     protected abstract CustomerDto createExistingCustomer() throws ApiGatewayException;
 
-    protected VocabularySettingsList sendRequestAcceptingJsonLd(UUID uuid) throws IOException {
+    protected VocabularyList sendRequestAcceptingJsonLd(UUID uuid) throws IOException {
         return sendRequest(uuid, MediaTypes.APPLICATION_JSON_LD);
     }
 
-    protected VocabularySettingsList sendRequest(UUID uuid, MediaType acceptedContentType) throws IOException {
-        VocabularySettingsList expectedBody = createRandomVocabularyList();
+    protected VocabularyList sendRequest(UUID uuid, MediaType acceptedContentType) throws IOException {
+        VocabularyList expectedBody = createRandomVocabularyList();
         InputStream request = addVocabularyForCustomer(uuid, expectedBody, acceptedContentType);
         handler.handleRequest(request, outputStream, CONTEXT);
         return expectedBody;
     }
 
-    protected String responseContentType(GatewayResponse<VocabularySettingsList> response) {
+    protected String responseContentType(GatewayResponse<VocabularyList> response) {
         return response.getHeaders().get(HttpHeaders.CONTENT_TYPE);
     }
 
@@ -72,8 +71,8 @@ public abstract class CreateUpdateControlledVocabularySettingsTests extends Cust
         return existingCustomer.getIdentifier();
     }
 
-    protected VocabularySettingsList createRandomVocabularyList() {
-        return new VocabularySettingsList(CustomerDataGenerator.randomVocabularyDtoSettings());
+    protected VocabularyList createRandomVocabularyList() {
+        return new VocabularyList(CustomerDataGenerator.randomVocabularyDtoSettings());
     }
 
     protected <T> InputStream addVocabularyForCustomer(UUID customerIdentifer, T expectedBody,
@@ -103,8 +102,8 @@ public abstract class CreateUpdateControlledVocabularySettingsTests extends Cust
         InputStream getRequest = createGetRequest(existingIdentifier(), MediaType.JSON_UTF_8);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         getHandler.handleRequest(getRequest, outputStream, CONTEXT);
-        GatewayResponse<VocabularySettingsList> getResponse = GatewayResponse.fromOutputStream(outputStream);
-        VocabularySettingsList getResponseObject = getResponse.getBodyObject(VocabularySettingsList.class);
-        assertThat(getResponseObject.getVocabularySettings(), is(empty()));
+        GatewayResponse<VocabularyList> getResponse = GatewayResponse.fromOutputStream(outputStream);
+        VocabularyList getResponseObject = getResponse.getBodyObject(VocabularyList.class);
+        assertThat(getResponseObject.getVocabularies(), is(empty()));
     }
 }

--- a/customer/src/test/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer/src/test/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -15,8 +15,8 @@ import java.util.stream.Collectors;
 import no.unit.nva.customer.model.CustomerDao;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.model.LinkedDataContextUtils;
-import no.unit.nva.customer.model.VocabularySettingDb;
-import no.unit.nva.customer.model.VocabularySettingDto;
+import no.unit.nva.customer.model.VocabularyDao;
+import no.unit.nva.customer.model.VocabularyDto;
 import no.unit.nva.customer.model.VocabularyStatus;
 
 public class CustomerDataGenerator {
@@ -41,17 +41,17 @@ public class CustomerDataGenerator {
             .withInstitutionDns(randomString())
             .withDisplayName(randomString())
             .withCreatedDate(randomInstant())
-            .withVocabularySettings(randomVocabularyDtoSettings())
+            .withVocabularies(randomVocabularyDtoSettings())
             .build();
 
         assertThat(customer, doesNotHaveEmptyValues());
         return customer;
     }
 
-    public static Set<VocabularySettingDto> randomVocabularyDtoSettings() {
+    public static Set<VocabularyDto> randomVocabularyDtoSettings() {
         return randomVocabularySettings()
             .stream()
-            .map(VocabularySettingDb::toVocabularySettingsDto)
+            .map(VocabularyDao::toVocabularySettingsDto)
             .collect(Collectors.toSet());
     }
 
@@ -74,9 +74,9 @@ public class CustomerDataGenerator {
         return customer;
     }
 
-    public static Set<VocabularySettingDb> randomVocabularySettings() {
-        VocabularySettingDb vocabulary = new VocabularySettingDb(randomString(), randomUri(),
-                                                                 randomElement(VocabularyStatus.values()));
+    public static Set<VocabularyDao> randomVocabularySettings() {
+        VocabularyDao vocabulary = new VocabularyDao(randomString(), randomUri(),
+                                                     randomElement(VocabularyStatus.values()));
         return Set.of(vocabulary);
     }
 

--- a/customer/src/test/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandlerTest.java
@@ -17,8 +17,8 @@ import java.util.Set;
 import java.util.UUID;
 import no.unit.nva.customer.ControlledVocabularyHandler;
 import no.unit.nva.customer.model.CustomerDto;
-import no.unit.nva.customer.model.VocabularySettingDto;
-import no.unit.nva.customer.model.interfaces.VocabularySettingsList;
+import no.unit.nva.customer.model.VocabularyDto;
+import no.unit.nva.customer.model.interfaces.VocabularyList;
 import no.unit.nva.customer.testing.CreateUpdateControlledVocabularySettingsTests;
 import no.unit.nva.customer.testing.CustomerDataGenerator;
 import nva.commons.apigateway.GatewayResponse;
@@ -34,33 +34,33 @@ public class UpdateControlledVocabularyHandlerTest extends CreateUpdateControlle
     @Test
     public void handleRequestReturnsAcceptedWhenUpdatingVocabularyForExistingCustomer() throws IOException {
         sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_ACCEPTED)));
     }
 
     @Test
     public void handleRequestReturnsUpdatedVocabularyListWhenUpdatingVocabularyForExistingCustomer()
         throws IOException {
-        VocabularySettingsList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
-        VocabularySettingsList body = response.getBodyObject(VocabularySettingsList.class);
+        VocabularyList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
+        VocabularyList body = response.getBodyObject(VocabularyList.class);
         assertThat(body, is(equalTo(expectedBody)));
     }
 
     @Test
     public void handleRequestSavesVocabularySettingsToDatabaseWhenUpdatingSettingsForExistingCustomer()
         throws IOException, ApiGatewayException {
-        VocabularySettingsList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
-        Set<VocabularySettingDto> savedVocabularySettings =
-            customerService.getCustomer(existingIdentifier()).getVocabularySettings();
-        assertThat(savedVocabularySettings, is(equalTo(expectedBody.getVocabularySettings())));
+        VocabularyList expectedBody = sendRequestAcceptingJsonLd(existingIdentifier());
+        Set<VocabularyDto> savedVocabularySettings =
+            customerService.getCustomer(existingIdentifier()).getVocabularies();
+        assertThat(savedVocabularySettings, is(equalTo(expectedBody.getVocabularies())));
     }
 
     @Test
     public void handleRequestReturnsNotFoundWhenTryingToSaveSettingsForNonExistingCustomer()
         throws IOException {
         sendRequestAcceptingJsonLd(UUID.randomUUID());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
     }
 
@@ -71,21 +71,21 @@ public class UpdateControlledVocabularyHandlerTest extends CreateUpdateControlle
         InputStream request = addVocabularyForCustomer(existingIdentifier(), invalidBody,
                                                        MediaTypes.APPLICATION_JSON_LD);
         handler.handleRequest(request, outputStream, CONTEXT);
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonLdWhenAcceptHeaderIsJsonLd() throws IOException {
         sendRequestAcceptingJsonLd(existingIdentifier());
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         assertThat(responseContentType(response), is(equalTo(MediaTypes.APPLICATION_JSON_LD.toString())));
     }
 
     @Test
     public void handleRequestReturnsResponseWithContentTypeJsonWhenAcceptHeaderIsJson() throws IOException {
         sendRequest(existingIdentifier(), MediaType.JSON_UTF_8);
-        GatewayResponse<VocabularySettingsList> response = GatewayResponse.fromOutputStream(outputStream);
+        GatewayResponse<VocabularyList> response = GatewayResponse.fromOutputStream(outputStream);
         String content = responseContentType(response);
         assertThat(content, is(equalTo(MediaType.JSON_UTF_8.toString())));
     }
@@ -106,7 +106,7 @@ public class UpdateControlledVocabularyHandlerTest extends CreateUpdateControlle
         throws IOException, ApiGatewayException {
         CustomerDto customerWithoutVocabularySettings = CustomerDataGenerator
             .crateSampleCustomerDto().copy()
-            .withVocabularySettings(Collections.emptySet())
+            .withVocabularies(Collections.emptySet())
             .build();
         customerService.createCustomer(customerWithoutVocabularySettings);
         sendRequestAcceptingJsonLd(customerWithoutVocabularySettings.getIdentifier());


### PR DESCRIPTION
Changed the names of the types and classes to fit with the specification as defined in  https://gist.github.com/brinxmat/ce87ac0a739b2060fcd8091bab857175
Changes:
1. Renamed VocabularySetting(s) to Vocabulary(ies)
2. Added get/setVocabulary to Customer interface for consistency