### PR TITLE
Remove customer selection claims if customer is ambigous during login 

### DIFF
--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CognitoClaims.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CognitoClaims.java
@@ -11,8 +11,7 @@ public final class CognitoClaims {
     public static final String NVA_USERNAME_CLAIM = "custom:nvaUsername";
     public static final String TOP_ORG_CRISTIN_ID = "custom:topOrgCristinId";
     public static final String PERSON_CRISTIN_ID_CLAIM = "custom:cristinId";
-    public static final String EMPTY_CLAIM_VALUE = "null";
-    public static final String ALLOWED_CUSTOMER_CLAIM = "custom:allowedCustomers";
+    public static final String EMPTY_CLAIM = "null";
     public static final String ROLES_CLAIM = "custom:roles";
     public static final String ACCESS_RIGHTS_CLAIM = "custom:accessRights";
     public static final String PERSON_AFFILIATION_CLAIM = "custom:personAffiliation";

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CognitoClaims.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CognitoClaims.java
@@ -11,7 +11,7 @@ public final class CognitoClaims {
     public static final String NVA_USERNAME_CLAIM = "custom:nvaUsername";
     public static final String TOP_ORG_CRISTIN_ID = "custom:topOrgCristinId";
     public static final String PERSON_CRISTIN_ID_CLAIM = "custom:cristinId";
-    public static final String EMPTY_ALLOWED_CUSTOMERS = "null";
+    public static final String EMPTY_CLAIM_VALUE = "null";
     public static final String ALLOWED_CUSTOMER_CLAIM = "custom:allowedCustomers";
     public static final String ROLES_CLAIM = "custom:roles";
     public static final String ACCESS_RIGHTS_CLAIM = "custom:accessRights";

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
@@ -43,6 +43,8 @@ import no.unit.nva.useraccessservice.usercreation.cristin.person.CristinClient;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -52,6 +54,8 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeTy
 
 public class UserSelectionUponLoginHandler
     implements RequestHandler<CognitoUserPoolPreTokenGenerationEvent, CognitoUserPoolPreTokenGenerationEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserSelectionUponLoginHandler.class);
 
     public static final Environment ENVIRONMENT = new Environment();
 
@@ -166,10 +170,14 @@ public class UserSelectionUponLoginHandler
         Collection<String> accessRights,
         Collection<String> roles) {
 
+        Collection<AttributeType> userAttributes = updatedPersonAttributes(authenticationInfo, accessRights, roles);
+
+        LOGGER.info("Updating user attributes: {}", userAttributes);
+
         return AdminUpdateUserAttributesRequest.builder()
                    .userPoolId(input.getUserPoolId())
                    .username(input.getUserName())
-                   .userAttributes(updatedPersonAttributes(authenticationInfo, accessRights, roles))
+                   .userAttributes(userAttributes)
                    .build();
     }
 

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
@@ -44,8 +44,6 @@ import no.unit.nva.useraccessservice.usercreation.cristin.person.CristinClient;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -55,8 +53,6 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeTy
 
 public class UserSelectionUponLoginHandler
     implements RequestHandler<CognitoUserPoolPreTokenGenerationEvent, CognitoUserPoolPreTokenGenerationEvent> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserSelectionUponLoginHandler.class);
 
     public static final Environment ENVIRONMENT = new Environment();
 
@@ -172,8 +168,6 @@ public class UserSelectionUponLoginHandler
         Collection<String> roles) {
 
         Collection<AttributeType> userAttributes = updatedPersonAttributes(authenticationInfo, accessRights, roles);
-
-        LOGGER.info("Updating user attributes: {}", userAttributes);
 
         return AdminUpdateUserAttributesRequest.builder()
                    .userPoolId(input.getUserPoolId())

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
@@ -3,11 +3,11 @@ package no.unit.nva.cognito;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.cognito.CognitoClaims.ACCESS_RIGHTS_CLAIM;
-import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMER_CLAIM;
+import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMERS_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.CLAIMS_TO_BE_SUPPRESSED_FROM_PUBLIC;
 import static no.unit.nva.cognito.CognitoClaims.CURRENT_CUSTOMER_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.ELEMENTS_DELIMITER;
-import static no.unit.nva.cognito.CognitoClaims.EMPTY_CLAIM_VALUE;
+import static no.unit.nva.cognito.CognitoClaims.EMPTY_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.NVA_USERNAME_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_AFFILIATION_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_CRISTIN_ID_CLAIM;
@@ -203,7 +203,7 @@ public class UserSelectionUponLoginHandler
         claims.add(createAttribute("custom:lastName", authenticationInfo.extractLastName()));
         claims.add(createAttribute(ACCESS_RIGHTS_CLAIM, String.join(ELEMENTS_DELIMITER, accessRights)));
         claims.add(createAttribute(ROLES_CLAIM, String.join(ELEMENTS_DELIMITER, roles)));
-        claims.add(createAttribute(ALLOWED_CUSTOMER_CLAIM, allowedCustomersString));
+        claims.add(createAttribute(ALLOWED_CUSTOMERS_CLAIM, allowedCustomersString));
         claims.add(createAttribute(PERSON_CRISTIN_ID_CLAIM, authenticationInfo.getCristinPersonId().toString()));
         addCustomerSelectionClaimsWhenUserHasOnePossibleLoginOrLoggedInWithFeide(authenticationInfo, claims);
         return claims;
@@ -219,7 +219,7 @@ public class UserSelectionUponLoginHandler
     }
 
     private Runnable clearCustomerSelectionClaimsWhenCustomerIsAmbiguous(List<AttributeType> claims) {
-        return () -> claims.addAll(emptyCustomerSelectionClaims());
+        return () -> claims.addAll(overwriteCustomerSelectionClaimsWithNullString());
     }
 
     private Consumer<String> generateCustomerSelectionClaimsFromAuthentication(
@@ -229,11 +229,11 @@ public class UserSelectionUponLoginHandler
         return customerId -> claims.addAll(customerSelectionClaims(authenticationInfo, customerId));
     }
 
-    private List<AttributeType> emptyCustomerSelectionClaims() {
-        return generateCustomerSelectionClaims(EMPTY_CLAIM_VALUE,
-                                               EMPTY_CLAIM_VALUE,
-                                               EMPTY_CLAIM_VALUE,
-                                               EMPTY_CLAIM_VALUE);
+    private List<AttributeType> overwriteCustomerSelectionClaimsWithNullString() {
+        return generateCustomerSelectionClaims(EMPTY_CLAIM,
+                                               EMPTY_CLAIM,
+                                               EMPTY_CLAIM,
+                                               EMPTY_CLAIM);
     }
 
     private List<AttributeType> customerSelectionClaims(AuthenticationInformation authenticationInfo,
@@ -266,7 +266,7 @@ public class UserSelectionUponLoginHandler
                          .collect(Collectors.joining(ELEMENTS_DELIMITER));
         return StringUtils.isNotBlank(result)
                    ? result
-                   : EMPTY_CLAIM_VALUE;
+                   : EMPTY_CLAIM;
     }
 
     private Predicate<CustomerDto> isNotFeideRequestOrIsFeideRequestForCustomer(String feideDomain) {

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
@@ -7,7 +7,7 @@ import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMER_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.CLAIMS_TO_BE_SUPPRESSED_FROM_PUBLIC;
 import static no.unit.nva.cognito.CognitoClaims.CURRENT_CUSTOMER_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.ELEMENTS_DELIMITER;
-import static no.unit.nva.cognito.CognitoClaims.EMPTY_ALLOWED_CUSTOMERS;
+import static no.unit.nva.cognito.CognitoClaims.EMPTY_CLAIM_VALUE;
 import static no.unit.nva.cognito.CognitoClaims.NVA_USERNAME_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_AFFILIATION_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_CRISTIN_ID_CLAIM;
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import no.unit.nva.auth.AuthorizedBackendClient;
@@ -219,19 +220,46 @@ public class UserSelectionUponLoginHandler
         List<AttributeType> claims) {
 
         authenticationInfo.getCurrentCustomerId()
-            .ifPresent(customerId -> claims.addAll(customerSelectionClaims(authenticationInfo, customerId)));
+            .ifPresentOrElse(generateCustomerSelectionClaimsFromAuthentication(authenticationInfo, claims),
+                             clearCustomerSelectionClaimsWhenCustomerIsAmbiguous(claims));
+    }
+
+    private Runnable clearCustomerSelectionClaimsWhenCustomerIsAmbiguous(List<AttributeType> claims) {
+        return () -> claims.addAll(emptyCustomerSelectionClaims());
+    }
+
+    private Consumer<String> generateCustomerSelectionClaimsFromAuthentication(
+        AuthenticationInformation authenticationInfo,
+        List<AttributeType> claims) {
+        
+        return customerId -> claims.addAll(customerSelectionClaims(authenticationInfo, customerId));
+    }
+
+    private List<AttributeType> emptyCustomerSelectionClaims() {
+        return generateCustomerSelectionClaims(EMPTY_CLAIM_VALUE,
+                                               EMPTY_CLAIM_VALUE,
+                                               EMPTY_CLAIM_VALUE,
+                                               EMPTY_CLAIM_VALUE);
     }
 
     private List<AttributeType> customerSelectionClaims(AuthenticationInformation authenticationInfo,
                                                         String customerId) {
+        return generateCustomerSelectionClaims(customerId,
+                                               authenticationInfo.getCurrentCustomer().getCristinId().toString(),
+                                               authenticationInfo.getCurrentUser().getUsername(),
+                                               authenticationInfo.getCurrentUser().getAffiliation().toString());
+    }
+
+    private List<AttributeType> generateCustomerSelectionClaims(String customerId,
+                                                                String topOrgCristinId,
+                                                                String username,
+                                                                String personAffiliation) {
 
         var currentCustomerClaim = createAttribute(CURRENT_CUSTOMER_CLAIM, customerId);
-        var currentTopLevelOrgClaim =
-            createAttribute(TOP_ORG_CRISTIN_ID, authenticationInfo.getCurrentCustomer().getCristinId().toString());
-        var usernameClaim =
-            createAttribute(NVA_USERNAME_CLAIM, authenticationInfo.getCurrentUser().getUsername());
-        var personAffiliationClaim =
-            createAttribute(PERSON_AFFILIATION_CLAIM, authenticationInfo.getCurrentUser().getAffiliation().toString());
+        var currentTopLevelOrgClaim = createAttribute(TOP_ORG_CRISTIN_ID, topOrgCristinId);
+        var usernameClaim = createAttribute(NVA_USERNAME_CLAIM, username);
+        var personAffiliationClaim = createAttribute(PERSON_AFFILIATION_CLAIM, personAffiliation);
+
         return List.of(currentCustomerClaim, currentTopLevelOrgClaim, usernameClaim, personAffiliationClaim);
     }
 
@@ -244,13 +272,13 @@ public class UserSelectionUponLoginHandler
                          .collect(Collectors.joining(ELEMENTS_DELIMITER));
         return StringUtils.isNotBlank(result)
                    ? result
-                   : EMPTY_ALLOWED_CUSTOMERS;
+                   : EMPTY_CLAIM_VALUE;
     }
 
     private Predicate<CustomerDto> isNotFeideRequestOrIsFeideRequestForCustomer(String feideDomain) {
         return customer -> isNull(feideDomain)
                            || nonNull(customer.getFeideOrganizationDomain())
-                           && customer.getFeideOrganizationDomain().equals(feideDomain);
+                              && customer.getFeideOrganizationDomain().equals(feideDomain);
     }
 
     private AttributeType createAttribute(String name, String value) {

--- a/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/UserSelectionUponLoginHandlerTest.java
+++ b/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/UserSelectionUponLoginHandlerTest.java
@@ -3,9 +3,9 @@ package no.unit.nva.cognito;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.cognito.AuthenticationInformation.COULD_NOT_FIND_USER_FOR_CUSTOMER_ERROR;
 import static no.unit.nva.cognito.CognitoClaims.ACCESS_RIGHTS_CLAIM;
-import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMER_CLAIM;
+import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMERS_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.CURRENT_CUSTOMER_CLAIM;
-import static no.unit.nva.cognito.CognitoClaims.EMPTY_CLAIM_VALUE;
+import static no.unit.nva.cognito.CognitoClaims.EMPTY_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.NVA_USERNAME_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_AFFILIATION_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.PERSON_CRISTIN_ID_CLAIM;
@@ -290,10 +290,10 @@ class UserSelectionUponLoginHandlerTest {
         var nvaUsername = extractClaimFromCognitoUpdateRequest(NVA_USERNAME_CLAIM);
         var personAffiliation = extractClaimFromCognitoUpdateRequest(PERSON_AFFILIATION_CLAIM);
 
-        assertThat(customerId, is(equalTo(EMPTY_CLAIM_VALUE)));
-        assertThat(topOrgCristinId, is(equalTo(EMPTY_CLAIM_VALUE)));
-        assertThat(nvaUsername, is(equalTo(EMPTY_CLAIM_VALUE)));
-        assertThat(personAffiliation, is(equalTo(EMPTY_CLAIM_VALUE)));
+        assertThat(customerId, is(equalTo(EMPTY_CLAIM)));
+        assertThat(topOrgCristinId, is(equalTo(EMPTY_CLAIM)));
+        assertThat(nvaUsername, is(equalTo(EMPTY_CLAIM)));
+        assertThat(personAffiliation, is(equalTo(EMPTY_CLAIM)));
     }
 
     @ParameterizedTest(name = "should not assign access rights for active employment when institution (top-level "
@@ -727,7 +727,7 @@ class UserSelectionUponLoginHandlerTest {
     private List<URI> extractAllowedCustomersFromCongitoUpdateRequest() {
         return cognitoClient.getAdminUpdateUserRequest()
                    .userAttributes().stream()
-                   .filter(attribute -> attribute.name().equals(ALLOWED_CUSTOMER_CLAIM))
+                   .filter(attribute -> attribute.name().equals(ALLOWED_CUSTOMERS_CLAIM))
                    .map(AttributeType::value)
                    .map(concatenatedUris -> concatenatedUris.split(","))
                    .flatMap(Arrays::stream)


### PR DESCRIPTION
I selected the strategy that was already in use for the allowed customers claim to indicate that the claim has no value, which is to use the string value "null". I am open to other strategies like empty string or the string "empty", but I think "null" is familiar to all of us.

Customer selection claims covers the following claims:

- `custom:customerId`
- `custom:nvaUsername`
- `custom:topOrgCristinId`
- `custom:cristinId`

This change will basically force users with more than one active affiliation (employment) in Cristin to select the customer they want to log in to instead of assuming the same the user selected on previously logins when they log in not using Feide. 