### PR TITLE
Add unauthenticated user support

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -108,8 +108,43 @@ Resources:
           ProviderName: !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}'
         - ClientId: !Ref DLRApplicationClient
           ProviderName: !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${UserPool}'
+      IdentityPoolName: NvaIdentityPool
 
+  CognitoIdentityPoolRoleAttachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId: !Ref IdentityPool
+      Roles:
+        unauthenticated: !GetAtt UnauthenticatedUserRole.Arn
 
+  UnauthenticatedUserRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: NvaUnauthenticatedRole
+      Description: "IAM role to allow unauthenticated access to open APIs"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: Allow
+          Principal:
+            Federated:
+              - "cognito-identity.amazon.com"
+            Action:
+              - "sts:AssumeRoleWithWebIdentity"
+      Policies:
+        - PolicyName: unauthenticatedUserPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: ['execute-api:Invoke']
+                Resource:
+                  - !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/GET/publication'
+              - Effect: Deny
+                Action: ['execute-api:Invoke']
+                Resource:
+                  - !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/POST/publication'
+                  - !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*/PUT/publication'
 
   UpdateCognintoUserAttributesRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
- Uses the existing Identity pool to provide unauthenticated access
- Questions:
  - Is this the correct method of doing this for our case?
  - The circularity of having to define the APIs that allow unauthenticated access seems like a bad idea, what alternatives do we have? Are there previous examples?