### PR TITLE
removing array validation from viewingScope

### DIFF
--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
@@ -248,6 +248,7 @@ public class UpdateUserHandlerTest extends HandlerTest {
         includedUnits.add(illegalUri);
         var viewingScope = new HashMap<>();
         viewingScope.put(INCLUDED_UNITS, includedUnits);
+        viewingScope.put("type", "ViewingScope");
         return viewingScope;
     }
     

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/ViewingScopeDb.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/ViewingScopeDb.java
@@ -1,6 +1,5 @@
 package no.unit.nva.useraccessservice.dao;
 
-import static java.util.Objects.isNull;
 import static no.unit.nva.useraccessservice.dao.DynamoEntriesUtils.nonEmpty;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
@@ -40,7 +39,6 @@ public class ViewingScopeDb implements Typed {
     public ViewingScopeDb(Set<URI> includedUnits, Set<URI> excludedUnits) {
         this.includedUnits = nonEmptyOrDefault(includedUnits);
         this.excludedUnits = nonEmptyOrDefault(excludedUnits);
-        validate(includedUnits);
     }
     
     public static ViewingScopeDb fromViewingScope(ViewingScope dto) {
@@ -93,10 +91,9 @@ public class ViewingScopeDb implements Typed {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ViewingScopeDb)) {
+        if (!(o instanceof ViewingScopeDb that)) {
             return false;
         }
-        ViewingScopeDb that = (ViewingScopeDb) o;
         return Objects.equals(getIncludedUnits(), that.getIncludedUnits())
                && Objects.equals(getExcludedUnits(), that.getExcludedUnits());
     }
@@ -105,15 +102,7 @@ public class ViewingScopeDb implements Typed {
         var dao = new ViewingScopeDb();
         dao.setExcludedUnits(dto.getExcludedUnits());
         dao.setIncludedUnits(dto.getIncludedUnits());
-        validate(dao.getIncludedUnits());
         return dao;
-    }
-
-    private static Void validate(Set<URI> includedUnits) {
-        if (isNull(includedUnits) || includedUnits.isEmpty()) {
-            throw new IllegalArgumentException("Invalid Viewing Scope: \"includedUnits\" cannot be empty");
-        }
-        return null;
     }
 
     private Set<URI> nonEmptyOrDefault(Set<URI> units) {

--- a/user-access-public-model/build.gradle
+++ b/user-access-public-model/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project (':json-config')
     implementation libs.nva.core
     implementation libs.nva.apigateway
+    implementation libs.nva.json
     implementation libs.bundles.jackson
 
     compileOnly project(":user-access-commons")

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/UserDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/UserDto.java
@@ -58,6 +58,7 @@ public class UserDto implements WithCopy<Builder>, Typed {
     
     public UserDto() {
         roles = Collections.emptySet();
+        viewingScope = ViewingScope.emptyViewingScope();
     }
     
     /**

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/ViewingScope.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/ViewingScope.java
@@ -4,6 +4,9 @@ import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
@@ -12,7 +15,6 @@ import java.util.Objects;
 import java.util.Set;
 import no.unit.nva.identityservice.json.JsonConfig;
 import no.unit.nva.useraccessservice.constants.ServiceConstants;
-import no.unit.nva.useraccessservice.interfaces.Typed;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.JacocoGenerated;
 
@@ -25,107 +27,45 @@ import nva.commons.core.JacocoGenerated;
  * Administrator.
  */
 
-public class ViewingScope implements Typed {
-    
+@JsonTypeName(ViewingScope.TYPE)
+@JsonTypeInfo(use = Id.NAME, property = "type")
+public class ViewingScope {
+
     public static final String EXCLUDED_UNITS = "excludedUnits";
     public static final String INCLUDED_UNITS = "includedUnits";
-    public static final String VIEWING_SCOPE_TYPE = "ViewingScope";
-    
+    public static final String TYPE = "ViewingScope";
+
     @JsonProperty(INCLUDED_UNITS)
     private final Set<URI> includedUnits;
     @JsonProperty(EXCLUDED_UNITS)
     private final Set<URI> excludedUnits;
-    
+
     @JsonCreator
     public ViewingScope(@JsonProperty(INCLUDED_UNITS) Set<URI> includedUnits,
-                        @JsonProperty(EXCLUDED_UNITS) Set<URI> excludedUnits,
-                        @JsonProperty(TYPE_FIELD) String type
-    ) throws BadRequestException {
-        
+                        @JsonProperty(EXCLUDED_UNITS) Set<URI> excludedUnits) throws BadRequestException {
+
         this.includedUnits = toSet(includedUnits);
         this.excludedUnits = toSet(excludedUnits);
-        if (!VIEWING_SCOPE_TYPE.equals(type)) {
-            throw new BadRequestException("Expected type is " + VIEWING_SCOPE_TYPE);
-        }
-        validate();
+        validate(this.includedUnits);
+        validate(this.excludedUnits);
     }
-    
+
     public static ViewingScope defaultViewingScope(URI organizationId) {
         attempt(() -> validate(organizationId)).orElseThrow();
         return attempt(() -> ViewingScope.create(Set.of(organizationId), Collections.emptySet())).orElseThrow();
     }
-    
+
     public static ViewingScope create(Collection<URI> includedUnits, Collection<URI> excludedUnits)
         throws BadRequestException {
-        return new ViewingScope(toSet(includedUnits), toSet(excludedUnits), VIEWING_SCOPE_TYPE);
+        return new ViewingScope(toSet(includedUnits), toSet(excludedUnits));
     }
-    
+
     public static ViewingScope fromJson(String input) throws BadRequestException {
-        return attempt(() -> JsonConfig.readValue(input, ViewingScope.class))
-                   .orElseThrow(fail -> new BadRequestException("Could not read viewing scope:" + input));
+        return attempt(() -> JsonConfig.readValue(input, ViewingScope.class)).orElseThrow(
+            fail -> new BadRequestException("Could not read viewing scope:" + input));
     }
-    
-    @JacocoGenerated
-    public Set<URI> getIncludedUnits() {
-        return includedUnits;
-    }
-    
-    @JacocoGenerated
-    public Set<URI> getExcludedUnits() {
-        return excludedUnits;
-    }
-    
-    @Override
-    public String getType() {
-        return VIEWING_SCOPE_TYPE;
-    }
-    
-    @JacocoGenerated
-    @Override
-    public void setType(String type) {
-        if (!VIEWING_SCOPE_TYPE.equals(type)) {
-            throw new IllegalArgumentException("ViewingScope type is not " + VIEWING_SCOPE_TYPE);
-        }
-    }
-    
-    @JacocoGenerated
-    @Override
-    public int hashCode() {
-        return Objects.hash(getIncludedUnits(), getExcludedUnits());
-    }
-    
-    @JacocoGenerated
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ViewingScope)) {
-            return false;
-        }
-        ViewingScope that = (ViewingScope) o;
-        return Objects.equals(getIncludedUnits(), that.getIncludedUnits())
-               && Objects.equals(getExcludedUnits(), that.getExcludedUnits());
-    }
-    
-    @Override
-    public String toString() {
-        return attempt(() -> JsonConfig.writeValueAsString(this)).orElseThrow();
-    }
-    
-    private static Set<URI> toSet(Collection<URI> collection) {
-        return nonNull(collection) ? new HashSet<>(collection) : Collections.emptySet();
-    }
-    
-    private static boolean pathIsNotExpectedPath(URI uri) {
-        return !uri.getPath().startsWith(ServiceConstants.CRISTIN_PATH);
-    }
-    
-    private static boolean hostIsNotExpectedHost(URI uri) {
-        return !ServiceConstants.API_DOMAIN.equals(uri.getHost());
-    }
-    
-    private static Void validate(URI uri) throws BadRequestException {
+
+    public static Void validate(URI uri) throws BadRequestException {
         if (pathIsNotExpectedPath(uri)) {
             throw new BadRequestException("Unexpected path in Viewing Scope URI:" + uri);
         }
@@ -134,16 +74,53 @@ public class ViewingScope implements Typed {
         }
         return null;
     }
-    
+
     @JacocoGenerated
-    private void validate() throws BadRequestException {
-        if (includedUnits.isEmpty()) {
-            throw new BadRequestException("Invalid Viewing Scope: \"includedUnits\" cannot be empty");
-        }
-        validate(includedUnits);
-        validate(excludedUnits);
+    public Set<URI> getIncludedUnits() {
+        return includedUnits;
     }
-    
+
+    @JacocoGenerated
+    public Set<URI> getExcludedUnits() {
+        return excludedUnits;
+    }
+
+    @JacocoGenerated
+    @Override
+    public int hashCode() {
+        return Objects.hash(getIncludedUnits(), getExcludedUnits());
+    }
+
+    @JacocoGenerated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ViewingScope that)) {
+            return false;
+        }
+        return Objects.equals(getIncludedUnits(), that.getIncludedUnits()) && Objects.equals(getExcludedUnits(),
+                                                                                             that.getExcludedUnits());
+    }
+
+    @Override
+    public String toString() {
+        return attempt(() -> JsonConfig.writeValueAsString(this)).orElseThrow();
+    }
+
+    private static Set<URI> toSet(Collection<URI> collection) {
+        return nonNull(collection) ? new HashSet<>(collection) : Collections.emptySet();
+    }
+
+    private static boolean pathIsNotExpectedPath(URI uri) {
+        return !uri.getPath().startsWith(ServiceConstants.CRISTIN_PATH);
+    }
+
+    private static boolean hostIsNotExpectedHost(URI uri) {
+        return !ServiceConstants.API_DOMAIN.equals(uri.getHost());
+    }
+
     @JacocoGenerated
     private void validate(Collection<URI> uris) throws BadRequestException {
         for (URI uri : uris) {

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/ViewingScope.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/ViewingScope.java
@@ -50,9 +50,19 @@ public class ViewingScope {
         validate(this.excludedUnits);
     }
 
+    private ViewingScope() {
+
+        this.includedUnits = Set.of();
+        this.excludedUnits = Set.of();
+    }
+
     public static ViewingScope defaultViewingScope(URI organizationId) {
         attempt(() -> validate(organizationId)).orElseThrow();
         return attempt(() -> ViewingScope.create(Set.of(organizationId), Collections.emptySet())).orElseThrow();
+    }
+
+    public static ViewingScope emptyViewingScope()  {
+        return new ViewingScope();
     }
 
     public static ViewingScope create(Collection<URI> includedUnits, Collection<URI> excludedUnits)

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/UserDtoTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/UserDtoTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.hamcrest.core.StringContains.containsString;
@@ -32,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.identityservice.json.JsonConfig;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import nva.commons.apigateway.AccessRight;
@@ -92,6 +94,17 @@ class UserDtoTest extends DtoTest {
         
         assertThat(deserializedItem, is(equalTo(sampleUser)));
         assertThat(deserializedItem, is(not(sameInstance(sampleUser))));
+    }
+
+    @Test
+    void userDtoShouldContainEmptyViewingScopeWhenViewingScopeIsNotProvided()
+        throws InvalidEntryInternalException, IOException {
+        UserDto sampleUser = UserDto.newBuilder().build();
+        var json = toMap(sampleUser);
+
+        var viewingScope = toMap(JsonUtils.dtoObjectMapper.writeValueAsString(json.get("viewingScope")));
+        assertThat(viewingScope.get("includedUnits"), is(notNullValue()));
+        assertThat(viewingScope.get("excludedUnits"), is(notNullValue()));
     }
     
     @Test
@@ -227,10 +240,10 @@ class UserDtoTest extends DtoTest {
     }
     
     @Test
-    void shouldReturnEmptyViewingScopeSetWhenScopeIsNotExplicitlyDefinedAndUserIsNotConnectedToSomeTopLevelOrg() {
+    void shouldReturnViewingScopeWithEmptySetsWhenScopeIsNotExplicitlyDefinedAndUserIsNotConnectedToSomeTopLevelOrg() {
         var user = createUserWithRoleWithoutInstitution();
         var viewingScope = user.getViewingScope();
-        assertThat(viewingScope, is(equalTo(null)));
+        assertThat(viewingScope, is(notNullValue()));
     }
     
     private UserDto createUserWithRoleAndInstitutionWithoutViewingScope() {

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/ViewingScopeTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/ViewingScopeTest.java
@@ -2,13 +2,15 @@ package no.unit.nva.useraccessservice.model;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.useraccessservice.model.ViewingScope.VIEWING_SCOPE_TYPE;
 import static no.unit.nva.useraccessservice.model.ViewingScope.defaultViewingScope;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import no.unit.nva.commons.json.JsonUtils;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.util.Set;
@@ -20,12 +22,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ViewingScopeTest {
-    
+
     public static Stream<ViewingScope> viewingScopeProvider() throws BadRequestException {
-        return Stream.of(new ViewingScope(Set.of(randomCristinOrgId()), null, VIEWING_SCOPE_TYPE),
-            new ViewingScope(Set.of(randomCristinOrgId()), Set.of(randomCristinOrgId()), VIEWING_SCOPE_TYPE));
+        return Stream.of(new ViewingScope(Set.of(randomCristinOrgId()), null),
+                         new ViewingScope(Set.of(randomCristinOrgId()), Set.of(randomCristinOrgId())));
     }
-    
+
     @Test
     void viewingScopeIsSerializedWithType() throws BadRequestException, IOException {
         ViewingScope viewingScope = randomViewingScope();
@@ -33,13 +35,13 @@ class ViewingScopeTest {
         var jsonMap = JsonConfig.mapFrom(jsonString);
         assertThat(jsonMap, hasEntry("type", "ViewingScope"));
     }
-    
+
     @Test
     void defaultViewingScopeReturnsViewingScope() {
         ViewingScope viewingScope = defaultViewingScope(randomCristinOrgId());
         assertThat(viewingScope.getIncludedUnits().size(), is(equalTo(1)));
     }
-    
+
     @ParameterizedTest
     @MethodSource("viewingScopeProvider")
     void shouldSerializeAndDeserialize() throws BadRequestException {
@@ -48,14 +50,26 @@ class ViewingScopeTest {
         var deserialized = ViewingScope.fromJson(json);
         assertThat(deserialized, is(equalTo(viewingScope)));
     }
-    
+
     @Test
     void shouldThrowBadRequestExceptionWhenParsingFails() {
         var invalidJson = randomString();
         var exception = assertThrows(BadRequestException.class, () -> ViewingScope.fromJson(invalidJson));
         assertThat(exception.getMessage(), containsString(invalidJson));
     }
-    
+
+    @Test
+    void shouldDeserializeNullViewingScopeToViewingScopeWithEmptyList() throws JsonProcessingException {
+        var json = """
+            {
+              "type": "ViewingScope"
+            }
+            """;
+        var viewingScope = JsonUtils.dtoObjectMapper.readValue(json, ViewingScope.class);
+        assertThat(viewingScope.getExcludedUnits(), is(emptyIterable()));
+        assertThat(viewingScope.getIncludedUnits(), is(emptyIterable()));
+    }
+
     private ViewingScope randomViewingScope() throws BadRequestException {
         return ViewingScope.create(Set.of(randomCristinOrgId()), Set.of(randomCristinOrgId()));
     }


### PR DESCRIPTION
- Removing validation of empty array from viewingScope (Array entries are still validated)
- Removed "type" variable from ViewingScope - using Jackson annotation instead