### PR TITLE
allowing manage-own-affiliation to update vocabularies

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDao.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.customer.model.CustomerDto.DoiAgentDto;
+import no.unit.nva.customer.model.CustomerDto.ServiceCenter;
 import no.unit.nva.customer.model.dynamo.converters.DoiAgentConverter;
 import no.unit.nva.customer.model.dynamo.converters.RightsRetentionStrategyConverter;
 import no.unit.nva.customer.model.dynamo.converters.VocabularyConverterProvider;
@@ -61,7 +62,6 @@ public class CustomerDao implements Typed {
     private URI customerOf;
     private Set<VocabularyDao> vocabularies;
     private URI rorId;
-    private URI serviceCenterUri;
     private PublicationWorkflow publicationWorkflow;
     private DoiAgentDao doiAgent;
     private ServiceCenterDao serviceCenter;
@@ -98,7 +98,6 @@ public class CustomerDao implements Typed {
                    .withName(dto.getName())
                    .withPublicationWorkflow(dto.getPublicationWorkflow())
                    .withRorId(dto.getRorId())
-                   .withServiceCenterUri(dto.getServiceCenterUri())
                    .withServiceCenter(dto.getServiceCenter().toDao())
                    .withShortName(dto.getShortName())
                    .withVocabularySettings(extractVocabularySettings(dto))
@@ -130,7 +129,7 @@ public class CustomerDao implements Typed {
     }
 
     public boolean isGeneralSupportEnabled() {
-        return true;
+        return generalSupportEnabled;
     }
 
     public void setGeneralSupportEnabled(boolean generalSupportEnabled) {
@@ -257,14 +256,6 @@ public class CustomerDao implements Typed {
         this.rorId = rorId;
     }
 
-    public URI getServiceCenterUri() {
-        return serviceCenterUri;
-    }
-
-    public void setServiceCenterUri(URI serviceCenterUri) {
-        this.serviceCenterUri = serviceCenterUri;
-    }
-
     public PublicationWorkflow getPublicationWorkflow() {
         return nonNull(publicationWorkflow) ? publicationWorkflow
                    : PublicationWorkflow.REGISTRATOR_PUBLISHES_METADATA_AND_FILES;
@@ -356,7 +347,6 @@ public class CustomerDao implements Typed {
                && Objects.equals(getCustomerOf(), that.getCustomerOf())
                && Objects.equals(getVocabularies(), that.getVocabularies())
                && Objects.equals(getRorId(), that.getRorId())
-               && Objects.equals(getServiceCenterUri(), that.getServiceCenterUri())
                && getPublicationWorkflow() == that.getPublicationWorkflow()
                && Objects.equals(getDoiAgent(), that.getDoiAgent())
                && Objects.equals(getServiceCenter(), that.getServiceCenter())
@@ -372,7 +362,7 @@ public class CustomerDao implements Typed {
         return Objects.hash(getIdentifier(), getCreatedDate(), getModifiedDate(), getName(), getDisplayName(),
                             getShortName(), getArchiveName(), getCname(), getInstitutionDns(),
                             getFeideOrganizationDomain(),
-                            getCristinId(), getCustomerOf(), getVocabularies(), getRorId(), getServiceCenterUri(),
+                            getCristinId(), getCustomerOf(), getVocabularies(), getRorId(),
                             getPublicationWorkflow(), getDoiAgent(), getServiceCenter(), isNviInstitution(),
                             isRboInstitution(), isGeneralSupportEnabled(), getInactiveFrom(), getSector(),
                             getRightsRetentionStrategy(), getAllowFileUploadForTypes());
@@ -394,7 +384,7 @@ public class CustomerDao implements Typed {
                                       .withCristinId(getCristinId())
                                       .withCustomerOf(fromUri(getCustomerOf()))
                                       .withRorId(getRorId())
-                                      .withServiceCenterUri(getServiceCenterUri())
+                                      .withServiceCenter(getServiceCenter().toDto())
                                       .withPublicationWorkflow(getPublicationWorkflow())
                                       .withDoiAgent(getDoiAgent())
                                       .withNviInstitution(isNviInstitution())
@@ -438,7 +428,6 @@ public class CustomerDao implements Typed {
                ", customerOf=" + customerOf +
                ", vocabularies=" + vocabularies +
                ", rorId=" + rorId +
-               ", serviceCenterUri=" + serviceCenterUri +
                ", publicationWorkflow=" + publicationWorkflow +
                ", doiAgent=" + doiAgent +
                ", nviInstitution=" + nviInstitution +
@@ -453,7 +442,7 @@ public class CustomerDao implements Typed {
     }
 
     public ServiceCenterDao getServiceCenter() {
-        return new ServiceCenterDao(serviceCenterUri, null);
+        return nonNull(serviceCenter) ? serviceCenter : new ServiceCenterDao();
     }
 
     public void setServiceCenter(ServiceCenterDao serviceCenter) {
@@ -576,11 +565,6 @@ public class CustomerDao implements Typed {
 
         public Builder withRorId(URI rorId) {
             customerDb.setRorId(rorId);
-            return this;
-        }
-
-        public Builder withServiceCenterUri(URI serviceCenterUri) {
-            customerDb.setServiceCenterUri(serviceCenterUri);
             return this;
         }
 
@@ -787,6 +771,7 @@ public class CustomerDao implements Typed {
         private URI uri;
         private String name;
 
+        @JacocoGenerated
         public ServiceCenterDao() {
         }
 
@@ -801,6 +786,10 @@ public class CustomerDao implements Typed {
             }
             ServiceCenterDao that = (ServiceCenterDao) o;
             return Objects.equals(getUri(), that.getUri()) && Objects.equals(getName(), that.getName());
+        }
+
+        public ServiceCenter toDto() {
+            return new ServiceCenter(uri, name);
         }
 
         @JacocoGenerated

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
@@ -52,7 +52,6 @@ public class CustomerDto implements Context {
     private ApplicationDomain customerOf;
     private List<VocabularyDto> vocabularies;
     private URI rorId;
-    private URI serviceCenterUri;
     private ServiceCenter serviceCenter;
     private PublicationWorkflow publicationWorkflow;
     private DoiAgentDto doiAgent;
@@ -207,14 +206,6 @@ public class CustomerDto implements Context {
         this.rorId = rorId;
     }
 
-    public URI getServiceCenterUri() {
-        return serviceCenterUri;
-    }
-
-    public void setServiceCenterUri(URI serviceCenterUri) {
-        this.serviceCenterUri = serviceCenterUri;
-    }
-
     public PublicationWorkflow getPublicationWorkflow() {
         return publicationWorkflow;
     }
@@ -276,7 +267,7 @@ public class CustomerDto implements Context {
     }
 
     public ServiceCenter getServiceCenter() {
-        return new ServiceCenter(serviceCenterUri, null);
+        return nonNull(serviceCenter) ? serviceCenter : ServiceCenter.emptyServiceCenter();
     }
 
     public void setServiceCenter(ServiceCenter serviceCenter) {
@@ -332,7 +323,6 @@ public class CustomerDto implements Context {
                    .withName(getName())
                    .withPublicationWorkflow(getPublicationWorkflow())
                    .withRorId(getRorId())
-                   .withServiceCenterUri(getServiceCenterUri())
                    .withShortName(getShortName())
                    .withDoiAgent(getDoiAgent())
                    .withNviInstitution(isNviInstitution())
@@ -352,7 +342,7 @@ public class CustomerDto implements Context {
         return Objects.hash(getContext(), getId(), getIdentifier(), getCreatedDate(), getModifiedDate(), getName(),
                             getDisplayName(), getShortName(), getArchiveName(), getCname(), getInstitutionDns(),
                             getFeideOrganizationDomain(), getCristinId(), getCustomerOf(), getVocabularies(),
-                            getRorId(), getServiceCenterUri(), getPublicationWorkflow(), getDoiAgent(),
+                            getRorId(), getPublicationWorkflow(), getDoiAgent(),
                             getRightsRetentionStrategy(), getAllowFileUploadForTypes(), getInactiveFrom(),
                             isGeneralSupportEnabled(), getServiceCenter());
     }
@@ -382,7 +372,6 @@ public class CustomerDto implements Context {
                && Objects.equals(getInactiveFrom(), that.getInactiveFrom())
                && Objects.equals(getName(), that.getName())
                && Objects.equals(getRorId(), that.getRorId())
-               && Objects.equals(getServiceCenterUri(), that.getServiceCenterUri())
                && Objects.equals(getServiceCenter(), that.getServiceCenter())
                && Objects.equals(getShortName(), that.getShortName())
                && Objects.equals(getVocabularies(), that.getVocabularies())
@@ -505,11 +494,6 @@ public class CustomerDto implements Context {
 
         public Builder withRorId(URI rorId) {
             customerDto.setRorId(rorId);
-            return this;
-        }
-
-        public Builder withServiceCenterUri(URI servceCenterUri) {
-            customerDto.setServiceCenterUri(servceCenterUri);
             return this;
         }
 
@@ -704,6 +688,10 @@ public class CustomerDto implements Context {
 
         public ServiceCenterDao toDao() {
             return new ServiceCenterDao(uri, name);
+        }
+
+        public static ServiceCenter emptyServiceCenter() {
+            return new ServiceCenter(null, null);
         }
     }
 }

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDaoTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDaoTest.java
@@ -43,8 +43,7 @@ class CustomerDaoTest {
         CustomerDto customerDto = expected.toCustomerDto();
         CustomerDao actual = CustomerDao.fromCustomerDto(customerDto);
         Diff diff = JAVERS.compare(expected, actual);
-        assertThat(customerDto, doesNotHaveEmptyValuesIgnoringFields(Set.of("doiAgent.password",
-                                                                            "serviceCenterDao.name")));
+        assertThat(customerDto, doesNotHaveEmptyValuesIgnoringFields(Set.of("doiAgent.password")));
 
         assertThat(diff.prettyPrint(), diff.hasChanges(), is(false));
         assertThat(actual, is(equalTo(expected)));
@@ -88,7 +87,7 @@ class CustomerDaoTest {
         CustomerDto customerDto = expected.toCustomerDto();
         CustomerDao actual = CustomerDao.fromCustomerDto(customerDto);
         Diff diff = JAVERS.compare(expected, actual);
-        assertThat(actual, doesNotHaveEmptyValuesIgnoringFields(Set.of("serviceCenter.name")));
+        assertThat(actual, doesNotHaveEmptyValues());
         assertThat(diff.prettyPrint(), diff.hasChanges(), is(false));
         assertThat(actual, is(equalTo(expected)));
     }
@@ -111,13 +110,6 @@ class CustomerDaoTest {
         var jsonString = JsonConfig.writeValueAsString(jsonMap);
         CustomerDao deserialized = JsonConfig.readValue(jsonString, CustomerDao.class);
         assertThat(deserialized, is(equalTo(someDao)));
-    }
-
-    @Test
-    void shouldCreateCustomerDaoWithIsAllowsGeneralSupportSetToTrueWhenNotSet() {
-        var dao = CustomerDao.builder().build();
-
-        assertThat(dao.isGeneralSupportEnabled(), is(true));
     }
 
     @Test
@@ -176,7 +168,6 @@ class CustomerDaoTest {
 
     private CustomerDao createSampleCustomerDao() {
         var identifier = UUID.randomUUID();
-        var serviceCenterUri = randomUri();
         return CustomerDao
                    .builder()
                    .withName(randomString())
@@ -192,8 +183,7 @@ class CustomerDaoTest {
                    .withDisplayName(randomString())
                    .withCreatedDate(randomInstant())
                    .withRorId(randomUri())
-                   .withServiceCenterUri(serviceCenterUri)
-                   .withServiceCenter(new ServiceCenterDao(serviceCenterUri, null))
+                   .withServiceCenter(new ServiceCenterDao(randomUri(), randomString()))
                    .withVocabularySettings(randomVocabularySettings())
                    .withPublicationWorkflow(randomPublicationWorkflow())
                    .withDoiAgent(randomDoiAgent(randomString()))

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDtoTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDtoTest.java
@@ -129,7 +129,6 @@ class CustomerDtoTest {
                    .withModifiedDate(randomInstant())
                    .withVocabularies(randomVocabularies())
                    .withRorId(randomUri())
-                   .withServiceCenterUri(randomUri())
                    .withPublicationWorkflow(randomPublicationWorkflow())
                    .withDoiAgent(randomDoiAgent(randomString()))
                    .withSector(randomSector())

--- a/customer-commons/src/test/java/no/unit/nva/customer/service/impl/DynamoDBCustomerServiceTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/service/impl/DynamoDBCustomerServiceTest.java
@@ -81,14 +81,6 @@ class DynamoDBCustomerServiceTest extends LocalCustomerServiceDatabase {
     }
 
     @Test
-    void createNewCustomerWithoutAllowsGeneralSupportBeingSetReturnCustomerAllowingGeneralSupport() throws NotFoundException, ConflictException {
-        var customer = CustomerDto.builder().withName(randomString()).build();
-        var createdCustomer = service.createCustomer(customer);
-
-        assertThat(createdCustomer.isGeneralSupportEnabled(), is(true));
-    }
-
-    @Test
     void updateExistingCustomerWithNewName() throws NotFoundException, InputException, ConflictException {
         String newName = "New name";
         var customer = newActiveCustomerDto();
@@ -371,7 +363,6 @@ class DynamoDBCustomerServiceTest extends LocalCustomerServiceDatabase {
                            .withCustomerOf(ApplicationDomain.fromUri(URI.create("")))
                            .withVocabularies(randomVocabularySet())
                            .withRorId(randomUri())
-                           .withServiceCenterUri(randomUri())
                            .withPublicationWorkflow(randomPublicationWorkflow())
                            .withDoiAgent(randomDoiAgent(randomString()))
                            .withSector(randomSector())

--- a/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -58,7 +58,6 @@ public class CustomerDataGenerator {
                                    .withCreatedDate(randomInstant())
                                    .withVocabularies(randomVocabularyDtoSettings())
                                    .withRorId(randomUri())
-                                   .withServiceCenterUri(randomUri())
                                    .withPublicationWorkflow(randomPublicationWorkflow())
                                    .withDoiAgent(randomDoiAgent(randomString()))
                                    .withSector(randomSector())
@@ -82,7 +81,6 @@ public class CustomerDataGenerator {
 
     public static CustomerDao createSampleInactiveCustomerDao() {
         VocabularyDao vocabulary = randomVocabularyDao();
-        URI serviceCenterUri = randomUri();
         CustomerDao customer = CustomerDao.builder()
                                    .withIdentifier(randomIdentifier())
                                    .withName(randomString())
@@ -98,8 +96,7 @@ public class CustomerDataGenerator {
                                    .withCname(randomString())
                                    .withArchiveName(randomString())
                                    .withRorId(randomUri())
-                                   .withServiceCenterUri(serviceCenterUri)
-                                   .withServiceCenter(new ServiceCenterDao(serviceCenterUri, null))
+                                   .withServiceCenter(new ServiceCenterDao(randomUri(), randomString()))
                                    .withPublicationWorkflow(randomPublicationWorkflow())
                                    .withDoiAgent(randomDoiAgent(randomString()))
                                    .withNviInstitution(randomBoolean())
@@ -109,8 +106,7 @@ public class CustomerDataGenerator {
                                    .withAllowFileUploadForTypes(randomAllowFileUploadForTypes())
                                    .withGeneralSupportEnabled(true)
                                    .build();
-        assertThat(customer, doesNotHaveEmptyValuesIgnoringFields(Set.of("serviceCenter.name",
-                                                                         "doiAgent.password")));
+        assertThat(customer, doesNotHaveEmptyValuesIgnoringFields(Set.of("doiAgent.password")));
         return customer;
     }
 

--- a/customer/src/main/java/no/unit/nva/customer/WriteControlledVocabularyHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/WriteControlledVocabularyHandler.java
@@ -1,6 +1,7 @@
 package no.unit.nva.customer;
 
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
+import static nva.commons.apigateway.AccessRight.MANAGE_OWN_AFFILIATION;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.UUID;
 import no.unit.nva.customer.model.CustomerDto;
@@ -37,6 +38,7 @@ public abstract class WriteControlledVocabularyHandler
 
     private boolean userIsAuthorized(RequestInfo requestInfo) {
         return requestInfo.clientIsInternalBackend()
-            || requestInfo.userIsAuthorized(MANAGE_CUSTOMERS);
+               || requestInfo.userIsAuthorized(MANAGE_CUSTOMERS)
+               || requestInfo.userIsAuthorized(MANAGE_OWN_AFFILIATION);
     }
 }

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateCustomerRequest.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateCustomerRequest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import no.unit.nva.customer.model.ApplicationDomain;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.model.CustomerDto.DoiAgentDto;
+import no.unit.nva.customer.model.CustomerDto.ServiceCenter;
 import no.unit.nva.customer.model.PublicationInstanceTypes;
 import no.unit.nva.customer.model.PublicationWorkflow;
 import no.unit.nva.customer.model.Sector;
@@ -44,7 +45,7 @@ public class CreateCustomerRequest {
     private Instant inactiveFrom;
     private Sector sector;
     private URI rorId;
-    private URI serviceCenterUri;
+    private ServiceCenter serviceCenter;
     private Set<PublicationInstanceTypes> allowFileUploadForTypes;
 
     public static CreateCustomerRequest fromCustomerDto(CustomerDto customerDto) {
@@ -65,7 +66,7 @@ public class CreateCustomerRequest {
         request.setRboInstitution(customerDto.isRboInstitution());
         request.setInactiveFrom(customerDto.getInactiveFrom());
         request.setRorId(customerDto.getRorId());
-        request.setServiceCenterUri(customerDto.getServiceCenterUri());
+        request.setServiceCenter(customerDto.getServiceCenter());
         request.setAllowFileUploadForTypes(customerDto.getAllowFileUploadForTypes());
         if (nonNull(customerDto.getDoiAgent())) {
             request.setDoiAgent(new DoiAgentDto(customerDto.getDoiAgent()));
@@ -92,8 +93,8 @@ public class CreateCustomerRequest {
                    .withInactiveFrom(getInactiveFrom())
                    .withSector(getSector())
                    .withRorId(getRorId())
-                   .withServiceCenterUri(getServiceCenterUri())
                    .withAllowFileUploadForTypes(getAllowFileUploadForTypes())
+                   .withServiceCenter(getServiceCenter())
                    .build();
     }
 
@@ -242,12 +243,12 @@ public class CreateCustomerRequest {
         this.rorId = rorId;
     }
 
-    public URI getServiceCenterUri() {
-        return serviceCenterUri;
+    public ServiceCenter getServiceCenter() {
+        return serviceCenter;
     }
 
-    public void setServiceCenterUri(URI serviceCenterUri) {
-        this.serviceCenterUri = serviceCenterUri;
+    public void setServiceCenter(ServiceCenter serviceCenterUri) {
+        this.serviceCenter = serviceCenterUri;
     }
 
     @JacocoGenerated
@@ -256,7 +257,7 @@ public class CreateCustomerRequest {
         return Objects.hash(getName(), getDisplayName(), getShortName(), getArchiveName(), getCname(),
                             getInstitutionDns(), getFeideOrganizationDomain(), getCristinId(), getVocabularies(),
                             getDoiAgent(), getSector(), isNviInstitution(), isRboInstitution(), getInactiveFrom(),
-                            getRorId(), getServiceCenterUri(), getAllowFileUploadForTypes());
+                            getRorId(), getServiceCenter(), getAllowFileUploadForTypes());
     }
 
     @JacocoGenerated
@@ -280,7 +281,7 @@ public class CreateCustomerRequest {
                && Objects.equals(getDoiAgent(), that.getDoiAgent())
                && Objects.equals(getSector(), that.getSector())
                && Objects.equals(getRorId(), that.getRorId())
-               && Objects.equals(getServiceCenterUri(), that.getServiceCenterUri())
+               && Objects.equals(getServiceCenter(), that.getServiceCenter())
                && Objects.equals(isNviInstitution(), that.isNviInstitution())
                && Objects.equals(isRboInstitution(), that.isRboInstitution())
                && Objects.equals(getInactiveFrom(), that.getInactiveFrom())

--- a/customer/src/test/java/no/unit/nva/customer/CustomerBatchScanHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/CustomerBatchScanHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.stream.IntStream;
 import no.unit.nva.customer.model.ApplicationDomain;
 import no.unit.nva.customer.model.CustomerDao;
 import no.unit.nva.customer.model.CustomerDto;
+import no.unit.nva.customer.model.CustomerDto.ServiceCenter;
 import no.unit.nva.customer.model.VocabularyDto;
 import no.unit.nva.customer.model.VocabularyStatus;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
@@ -84,7 +85,7 @@ public class CustomerBatchScanHandlerTest extends LocalCustomerServiceDatabase {
                            .withCustomerOf(ApplicationDomain.fromUri(URI.create("")))
                            .withVocabularies(randomVocabularySet())
                            .withRorId(randomUri())
-                           .withServiceCenterUri(randomUri())
+                           .withServiceCenter(new ServiceCenter(randomUri(), randomString()))
                            .withPublicationWorkflow(randomPublicationWorkflow())
                            .withDoiAgent(randomDoiAgent(randomString()))
                            .withSector(randomSector())

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateControlledVocabularyTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateControlledVocabularyTest.java
@@ -14,6 +14,7 @@ import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.model.VocabularyList;
 import no.unit.nva.customer.testing.CreateUpdateControlledVocabularySettingsTests;
 import no.unit.nva.customer.testing.CustomerDataGenerator;
+import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.MediaTypes;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -99,6 +100,12 @@ class CreateControlledVocabularyTest extends CreateUpdateControlledVocabularySet
         var result = sendRequestAcceptingJsonLd(existingIdentifier());
 
         assertThat(result.getResponse().getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
+    }
+
+    @Test
+    void handleRequestReturnsCreatedVocabularyListWhenUserWithAccessRightManageOwnAffiliationsCreatesVocabulary() throws IOException {
+        var result = sendRequestWithAccessRight(existingIdentifier(), AccessRight.MANAGE_OWN_AFFILIATION);
+        assertThat(result.getResponse().getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
     }
 
     @Override

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateCustomerHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateCustomerHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import no.unit.nva.customer.model.ApplicationDomain;
 import no.unit.nva.customer.model.CustomerDto;
+import no.unit.nva.customer.model.CustomerDto.ServiceCenter;
 import no.unit.nva.customer.model.PublicationInstanceTypes;
 import no.unit.nva.customer.model.Sector;
 import no.unit.nva.customer.service.CustomerService;
@@ -166,7 +167,7 @@ public class CreateCustomerHandlerTest extends LocalCustomerServiceDatabase {
         var customerDto =
             CustomerDto.builder()
                 .withName("New Customer")
-                .withServiceCenterUri(testServiceCenterUri)
+                .withServiceCenter(new ServiceCenter(testServiceCenterUri, randomString()))
                 .build();
         var requestBody = CreateCustomerRequest.fromCustomerDto(customerDto);
         var response = executeRequest(requestBody, CustomerDto.class);
@@ -303,7 +304,7 @@ public class CreateCustomerHandlerTest extends LocalCustomerServiceDatabase {
                    .withCustomerOf(randomElement(ApplicationDomain.values()))
                    .withDoiAgent(randomDoiAgent(randomString()))
                    .withRorId(randomUri())
-                   .withServiceCenterUri(randomUri())
+                   .withServiceCenter(new ServiceCenter(randomUri(), randomString()))
                    .withRightsRetentionStrategy(randomRightsRetentionStrategy())
                    .withAllowFileUploadForTypes(Collections.emptySet())
                    .build();

--- a/customer/src/test/java/no/unit/nva/customer/testing/CreateUpdateControlledVocabularySettingsTests.java
+++ b/customer/src/test/java/no/unit/nva/customer/testing/CreateUpdateControlledVocabularySettingsTests.java
@@ -23,6 +23,7 @@ import no.unit.nva.customer.model.VocabularyList;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.MediaTypes;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -61,6 +62,16 @@ public abstract class CreateUpdateControlledVocabularySettingsTests extends Loca
         return new ExpectedBodyActualResponseTuple(expectedBody, response);
     }
 
+    protected ExpectedBodyActualResponseTuple sendRequestWithAccessRight(UUID uuid, AccessRight accessRight)
+        throws IOException {
+        VocabularyList expectedBody = createRandomVocabularyList();
+        var request = createRequest(uuid, expectedBody, accessRight);
+        output = new ByteArrayOutputStream();
+        handler.handleRequest(request, output, CONTEXT);
+        var response = GatewayResponse.fromOutputStream(output, VocabularyList.class);
+        return new ExpectedBodyActualResponseTuple(expectedBody, response);
+    }
+
     protected <T> GatewayResponse<T> sendRequest(ControlledVocabularyHandler<?, ?> getHandler,
                                                  InputStream getRequest,
                                                  Class<T> responseType)
@@ -91,6 +102,15 @@ public abstract class CreateUpdateControlledVocabularySettingsTests extends Loca
             .withBody(expectedBody)
             .withHeaders(Map.of(HttpHeaders.ACCEPT, acceptedMediaType.toString()))
             .build();
+    }
+
+    protected <T> InputStream createRequest(UUID customerIdentifier, T expectedBody, AccessRight accessRight)
+        throws JsonProcessingException {
+        return new HandlerRequestBuilder<T>(dtoObjectMapper)
+                   .withPathParameters(identifierToPathParameter(customerIdentifier))
+                   .withAccessRights(randomUri(), accessRight)
+                   .withBody(expectedBody)
+                   .build();
     }
 
     protected Map<String, String> identifierToPathParameter(UUID identifier) {

--- a/customer/src/test/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/update/UpdateControlledVocabularyHandlerTest.java
@@ -17,6 +17,7 @@ import no.unit.nva.customer.model.VocabularyList;
 import no.unit.nva.customer.testing.CreateUpdateControlledVocabularySettingsTests;
 import no.unit.nva.customer.testing.CustomerDataGenerator;
 import no.unit.nva.stubs.FakeContext;
+import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.MediaTypes;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -105,6 +106,14 @@ public class UpdateControlledVocabularyHandlerTest extends CreateUpdateControlle
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
         String responseBody = response.getBody();
         assertThat(responseBody, containsString(VOCABULARY_SETTINGS_NOT_DEFINED_ERROR));
+    }
+
+    @Test
+    public void handleRequestReturnsUpdatedVocabularyListWhenUserWithAccessRightManageOwnAffiliationsUpdatesVocabulary()
+        throws IOException {
+        var result = sendRequestWithAccessRight(existingIdentifier(), AccessRight.MANAGE_OWN_AFFILIATION);
+        var actualBody = VocabularyList.fromJson(result.getResponse().getBody());
+        assertThat(actualBody, is(equalTo(result.getExpectedBody())));
     }
 
     private CustomerDto createCustomerWithoutVocabularySettings() {

--- a/customer/src/test/java/no/unit/nva/customer/update/UpdateCustomerHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/update/UpdateCustomerHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import no.unit.nva.customer.exception.InputException;
 import no.unit.nva.customer.model.ApplicationDomain;
 import no.unit.nva.customer.model.CustomerDto;
+import no.unit.nva.customer.model.CustomerDto.ServiceCenter;
 import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.testutils.HandlerRequestBuilder;
@@ -120,20 +121,20 @@ public class UpdateCustomerHandlerTest {
     }
 
     @Test
-    void requestToHandlerReturnsCustomerServiceCenterUriUpdated()
+    void requestToHandlerReturnsCustomerServiceCenterUpdated()
         throws InputException, NotFoundException, IOException {
         UUID identifier = UUID.randomUUID();
         CustomerDto customer = createCustomer(identifier);
         when(customerServiceMock.updateCustomer(any(UUID.class), any(CustomerDto.class))).thenReturn(customer);
-        assertThat(customer.getServiceCenterUri(), is(nullValue()));
+        assertThat(customer.getServiceCenter().uri(), is(nullValue()));
 
-        customer.setServiceCenterUri(testServiceCenterUri);
+        customer.setServiceCenter(new ServiceCenter(testServiceCenterUri, randomString()));
         when(customerServiceMock.updateCustomer(any(UUID.class), any(CustomerDto.class))).thenReturn(customer);
         Map<String, String> pathParameters = Map.of(IDENTIFIER, identifier.toString());
         var input = createInput(customer, pathParameters);
 
         sendRequest(input, CustomerDto.class);
-        assertThat(customer.getServiceCenterUri(), is(equalTo(testServiceCenterUri)));
+        assertThat(customer.getServiceCenter().uri(), is(equalTo(testServiceCenterUri)));
         verify(customerServiceMock, times(1)).updateCustomer(any(UUID.class), eq(customer));
     }
 


### PR DESCRIPTION
Implemented:

- Allowing user with access right manage-own-affiliation to update vocabularies
- Allowing user with access right manage-own-affiliation to create vocabularies
- Removed serviceCenter migration code
- Removed serviceCenterUri as it has been migrated to serviceCenter in all environments
- Removed migration code for generalSupportEnabled (made getter return actual value instead of always returning true)