### PR TITLE
Update refresh token validity

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1460,7 +1460,7 @@ Resources:
         - custom:impersonatedBy
       AccessTokenValidity: 1
       IdTokenValidity: 1
-      RefreshTokenValidity: 2
+      RefreshTokenValidity: 9
       TokenValidityUnits:
         AccessToken: hours
         IdToken: hours


### PR DESCRIPTION
Extend lifetime of the session token to 9 hours for the ApplicationClient. May argue that the same should be done for other clients as well.