### PR TITLE
NP-46866-security-headers

### DIFF
--- a/customer/src/test/java/no/unit/nva/customer/testing/TestHeaders.java
+++ b/customer/src/test/java/no/unit/nva/customer/testing/TestHeaders.java
@@ -3,15 +3,15 @@ package no.unit.nva.customer.testing;
 import static com.google.common.net.HttpHeaders.ACCEPT;
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.HttpHeaders.STRICT_TRANSPORT_SECURITY;
+import static com.google.common.net.HttpHeaders.X_CONTENT_TYPE_OPTIONS;
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import java.util.List;
 import java.util.Map;
 import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
 public class TestHeaders {
 
-    public static String APPLICATION_PROBLEM_JSON = "application/problem+json";
     public static String WILDCARD = "*";
 
     /**
@@ -25,12 +25,6 @@ public class TestHeaders {
             ACCEPT, JSON_UTF_8.toString());
     }
 
-    public static Map<String, List<String>> getMultiValuedHeaders() {
-        return Map.of(
-            CONTENT_TYPE, List.of(JSON_UTF_8.toString()),
-            ACCEPT, List.of(JSON_UTF_8.toString()));
-    }
-
     /**
      * Successful response headers for testing.
      *
@@ -39,19 +33,9 @@ public class TestHeaders {
     public static Map<String, String> getResponseHeaders() {
         return Map.of(
             CONTENT_TYPE, JSON_UTF_8.toString(),
-            ACCESS_CONTROL_ALLOW_ORIGIN, WILDCARD
-        );
-    }
-
-    /**
-     * Failing response headers for testing.
-     *
-     * @return headers
-     */
-    public static Map<String, String> getErrorResponseHeaders() {
-        return Map.of(
-            CONTENT_TYPE, APPLICATION_PROBLEM_JSON,
-            ACCESS_CONTROL_ALLOW_ORIGIN, WILDCARD
+            ACCESS_CONTROL_ALLOW_ORIGIN, WILDCARD,
+            STRICT_TRANSPORT_SECURITY, "max-age=63072000; includeSubDomains; preload",
+            X_CONTENT_TYPE_OPTIONS, "nosniff"
         );
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,24 @@
 [versions]
-nvaCommons = { strictly = '1.37.1' }
+nvaCommons = { strictly = '1.39.3' }
 # require awsSdk because of xraySdk using version 1.11.1000 and us using newer version.
 #awsSdk = { require = "1.11.1000" }
-awsSdk2 = { strictly = '2.23.12' }
+awsSdk2 = { strictly = '2.24.12' }
 jackson = { strictly = "2.16.1" }
 xraySdk = { strictly = '2.9.1' }
-dynamoDbLocal = { strictly = '1.19.0' }
+dynamoDbLocal = { strictly = '2.0.0' }
 zalandoProblem = { strictly = '0.27.1' }
 awsLambdaCore = { strictly = '1.2.3' }
 jupiter = { strictly = "5.10.1" }
-slf4j = { strictly = '2.0.11' }
+slf4j = { strictly = '2.0.12' }
 apacheHttpClient = { strictly = '4.5.13' }
 hamcrest = { strictly = '2.2' }
 javersCore = { strictly = '6.2.5' }
 datafaker = { strictly = '1.9.0' }
 mockitoCore = { strictly = '4.5.1' }
 apiGuardian = { strictly = '1.1.2' }
-guava = { strictly = '32.1.2-jre' }
+guava = { require = '32.1.2-jre' }
 hamcrestJackson = { strictly = '1.3.2' }
-log4j = { strictly = '2.22.1' }
+log4j = { strictly = '2.23.0' }
 awsLambdaEvents = { strictly = '3.11.4' }
 wiremock = { strictly = "3.0.2" }
 


### PR DESCRIPTION
Sett over at alle handlere som finnes i swagger spesifikasjonen arver ApiGatewayHandler.
Dette api'et kjører på java 17, men ser ut til å compile uten å måtte oppgradere til java 21.