### PR TITLE
Np 47131 prevent persistence of invalid role names

### DIFF
--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CustomerSelectionHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/CustomerSelectionHandler.java
@@ -23,6 +23,7 @@ import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.useraccessservice.model.CustomerSelection;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.useraccessservice.database.DatabaseConfig;
 import nva.commons.apigateway.AccessRight;
@@ -108,7 +109,10 @@ public class CustomerSelectionHandler extends CognitoCommunicationHandler<Custom
     }
 
     private String getActiveRoles(UserDto user) {
-        return user.getRoles().stream().map(RoleDto::getRoleName).collect(Collectors.joining(ELEMENTS_DELIMITER));
+        return user.getRoles().stream()
+                   .map(RoleDto::getRoleName)
+                   .map(RoleName::getValue)
+                   .collect(Collectors.joining(ELEMENTS_DELIMITER));
     }
 
     private String getActiveAccessRights(UserDto user, CustomerDto customer) {

--- a/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
+++ b/cognito-pre-token-generation-openid/src/main/java/no/unit/nva/cognito/UserSelectionUponLoginHandler.java
@@ -43,6 +43,7 @@ import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.usercreation.UserCreationContext;
 import no.unit.nva.useraccessservice.usercreation.UserEntriesCreatorForPerson;
@@ -359,7 +360,7 @@ public class UserSelectionUponLoginHandler
         return Optional.empty();
     }
 
-    private Set<String> rolesForCustomer(List<UserDto> usersForPerson, CustomerDto customer) {
+    private Set<RoleName> rolesForCustomer(List<UserDto> usersForPerson, CustomerDto customer) {
         if (isNull(customer)) {
             return Collections.emptySet();
         }
@@ -378,7 +379,7 @@ public class UserSelectionUponLoginHandler
         UserDto currentUser,
         Set<CustomerDto> customers,
         Collection<String> accessRights,
-        Collection<String> roles,
+        Collection<RoleName> roles,
         String impersonatedBy) {
 
         final var updateUserAttributesRequest = createUpdateUserAttributesRequest(
@@ -401,7 +402,7 @@ public class UserSelectionUponLoginHandler
         UserDto currentUser,
         Set<CustomerDto> customers,
         Collection<String> accessRights,
-        Collection<String> roles,
+        Collection<RoleName> roles,
         String impersonatedBy) {
 
         Collection<AttributeType> userAttributes = updatedPersonAttributes(person,
@@ -426,7 +427,7 @@ public class UserSelectionUponLoginHandler
                                                               UserDto currentUser,
                                                               Set<CustomerDto> customers,
                                                               Collection<String> accessRights,
-                                                              Collection<String> roles,
+                                                              Collection<RoleName> roles,
                                                               String impersonatedBy) {
 
         var allowedCustomersString = createAllowedCustomersString(customers, feideDomain);
@@ -445,7 +446,7 @@ public class UserSelectionUponLoginHandler
         CustomerDto currentCustomer,
         UserDto currentUser,
         Collection<String> accessRights,
-        Collection<String> roles,
+        Collection<RoleName> roles,
         String allowedCustomersString,
         String impersonatedBy) {
 
@@ -453,7 +454,7 @@ public class UserSelectionUponLoginHandler
         claims.add(createAttribute(FIRST_NAME_CLAIM, person.getFirstname()));
         claims.add(createAttribute(LAST_NAME_CLAIM, person.getSurname()));
         claims.add(createAttribute(ACCESS_RIGHTS_CLAIM, String.join(ELEMENTS_DELIMITER, accessRights)));
-        claims.add(createAttribute(ROLES_CLAIM, String.join(ELEMENTS_DELIMITER, roles)));
+        claims.add(createAttribute(ROLES_CLAIM, String.join(ELEMENTS_DELIMITER, roles.stream().map(RoleName::getValue).toList())));
         claims.add(createAttribute(ALLOWED_CUSTOMERS_CLAIM, allowedCustomersString));
         claims.add(createAttribute(PERSON_CRISTIN_ID_CLAIM, person.getId().toString()));
         claims.add(createAttribute(IMPERSONATED_BY_CLAIM, isNull(impersonatedBy) ? "" : impersonatedBy));

--- a/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/CustomerSelectionHandlerTest.java
+++ b/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/CustomerSelectionHandlerTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cognito;
 
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.cognito.CognitoClaims.ACCESS_RIGHTS_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.ALLOWED_CUSTOMERS_CLAIM;
 import static no.unit.nva.cognito.CognitoClaims.CURRENT_CUSTOMER_CLAIM;
@@ -58,7 +59,6 @@ import nva.commons.core.attempt.Try;
 import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.GetUserRequest;
@@ -136,7 +136,7 @@ class CustomerSelectionHandlerTest {
         var response = sendRequest(input, Void.class);
         var updatedRoles = extractAttributeUpdate(ROLES_CLAIM);
         var expectedRoles = role.getRoleName();
-        assertThat(updatedRoles, is(equalTo(expectedRoles)));
+        assertThat(updatedRoles, is(equalTo(expectedRoles.getValue())));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_OK)));
     }
     
@@ -232,7 +232,7 @@ class CustomerSelectionHandlerTest {
 
     private static RoleDb randomRoleWithAccessRight(AccessRight accessRight) {
         return RoleDb.newBuilder()
-                   .withName(randomString())
+                   .withName(randomRoleName())
                    .withAccessRights(Set.of(accessRight))
                    .build();
     }

--- a/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/UserSelectionUponLoginHandlerTest.java
+++ b/cognito-pre-token-generation-openid/src/test/java/no/unit/nva/cognito/UserSelectionUponLoginHandlerTest.java
@@ -97,7 +97,6 @@ import nva.commons.secrets.SecretsReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -1004,9 +1003,9 @@ class UserSelectionUponLoginHandlerTest {
 
     private RoleDto persistRoleToDatabase(Collection<AccessRight> accessRights)
         throws InvalidInputException, ConflictException, NotFoundException {
-        var role = RoleDto.newBuilder().withRoleName(randomRoleName()).withAccessRights(accessRights).build();
-        persistRole(role);
-        return identityService.getRole(role);
+        var roleDto = RoleDto.newBuilder().withRoleName(randomRoleNameButNot(RoleName.CREATOR)).withAccessRights(accessRights).build();
+        persistRole(roleDto);
+        return identityService.getRole(roleDto);
     }
 
     private void addAccessRightToExistingRole(RoleDto role, AccessRight accessRight)

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/CreateUserHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/CreateUserHandler.java
@@ -6,7 +6,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.customer.Constants.defaultCustomerService;
-import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_AFFILIATION;
 import static nva.commons.core.attempt.Try.attempt;
@@ -25,6 +24,7 @@ import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.handlers.models.CreateUserRequest;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.usercreation.UserCreationContext;
 import no.unit.nva.useraccessservice.usercreation.UserEntriesCreatorForPerson;
@@ -212,7 +212,7 @@ public class CreateUserHandler extends HandlerWithEventualConsistency<CreateUser
 
         var roles = input.roles().stream().map(RoleDto::getRoleName).collect(Collectors.toSet());
 
-        if (roles.contains(APP_ADMIN_ROLE_NAME) || !requestInfo.userIsAuthorized(MANAGE_OWN_AFFILIATION)) {
+        if (roles.contains(RoleName.APPLICATION_ADMIN) || !requestInfo.userIsAuthorized(MANAGE_OWN_AFFILIATION)) {
             throw new ForbiddenException();
         }
     }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/GetRoleHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/GetRoleHandler.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.database.IdentityServiceImpl;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -14,7 +15,6 @@ import nva.commons.core.JacocoGenerated;
 
 public class GetRoleHandler extends ApiGatewayHandler<Void, RoleDto> {
 
-    public static final String EMPTY_ROLE_NAME = "Role-name cannot be empty";
     public static final String ROLE_PATH_PARAMETER = "role";
 
     private final IdentityService databaseService;
@@ -35,7 +35,7 @@ public class GetRoleHandler extends ApiGatewayHandler<Void, RoleDto> {
     @Override
     public RoleDto processInput(Void input, RequestInfo requestInfo, Context context)
         throws NotFoundException {
-        String roleName = roleNameThatIsNotNullOrBlank(requestInfo);
+        var roleName = roleNameThatIsNotNullOrBlank(requestInfo);
 
         RoleDto searchObject = RoleDto.newBuilder().withRoleName(roleName).build();
         return databaseService.getRole(searchObject);
@@ -46,10 +46,11 @@ public class GetRoleHandler extends ApiGatewayHandler<Void, RoleDto> {
         return HttpURLConnection.HTTP_OK;
     }
 
-    private String roleNameThatIsNotNullOrBlank(RequestInfo requestInfo) {
+    private RoleName roleNameThatIsNotNullOrBlank(RequestInfo requestInfo) {
         return Optional.ofNullable(requestInfo.getPathParameters())
-            .map(pathParams -> pathParams.get(ROLE_PATH_PARAMETER))
-            .filter(not(String::isBlank))
-            .orElseThrow();
+                   .map(pathParams -> pathParams.get(ROLE_PATH_PARAMETER))
+                   .filter(not(String::isBlank))
+                   .map(RoleName::valueOf)
+                   .orElseThrow();
     }
 }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/GetRoleHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/GetRoleHandler.java
@@ -50,7 +50,7 @@ public class GetRoleHandler extends ApiGatewayHandler<Void, RoleDto> {
         return Optional.ofNullable(requestInfo.getPathParameters())
                    .map(pathParams -> pathParams.get(ROLE_PATH_PARAMETER))
                    .filter(not(String::isBlank))
-                   .map(RoleName::valueOf)
+                   .map(RoleName::fromValue)
                    .orElseThrow();
     }
 }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandler.java
@@ -1,6 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.handlers.data.DefaultRoleSource.NVI_CURATOR_ROLE;
+import static no.unit.nva.useraccessservice.model.RoleName.DEPRECATED_NVI_CURATOR;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
@@ -18,7 +19,6 @@ import org.slf4j.LoggerFactory;
 public class IdentityServiceMigrateCuratorHandler extends ApiGatewayHandler<Void, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(IdentityServiceMigrateCuratorHandler.class);
-    public static final String LEGACY_NVI_CURATOR_NAME = "Nvi-curator";
 
     private final IdentityService identityService;
 
@@ -47,7 +47,7 @@ public class IdentityServiceMigrateCuratorHandler extends ApiGatewayHandler<Void
     }
     
     private boolean userIsLegacyNviCurator(UserDto user) {
-        return user.getRoles().stream().map(RoleDto::getRoleName).anyMatch(LEGACY_NVI_CURATOR_NAME::equals);
+        return user.getRoles().stream().map(RoleDto::getRoleName).anyMatch(DEPRECATED_NVI_CURATOR::equals);
     }
 
     private UserDto attemptUpdateRolesForUser(UserDto user) {
@@ -65,7 +65,7 @@ public class IdentityServiceMigrateCuratorHandler extends ApiGatewayHandler<Void
 
     private Set<RoleDto> updateRoleSet(Set<RoleDto> roleSet) {
         roleSet.add(NVI_CURATOR_ROLE);
-        roleSet.removeIf(role -> LEGACY_NVI_CURATOR_NAME.equals(role.getRoleName()));
+        roleSet.removeIf(role -> DEPRECATED_NVI_CURATOR.equals(role.getRoleName()));
         return roleSet;
     }
 }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandler.java
@@ -1,13 +1,12 @@
 package no.unit.nva.handlers;
 
-import static no.unit.nva.handlers.data.DefaultRoleSource.NVI_CURATOR_ROLE;
-import static no.unit.nva.useraccessservice.model.RoleName.DEPRECATED_NVI_CURATOR;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
-import java.util.Set;
+import java.util.stream.Collectors;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -35,9 +34,8 @@ public class IdentityServiceMigrateCuratorHandler extends ApiGatewayHandler<Void
     @Override
     protected Void processInput(Void input, RequestInfo requestInfo, Context context) {
         identityService.listAllUsers().stream()
-            .filter(this::userIsLegacyNviCurator)
-            .forEach(this::attemptUpdateRolesForUser);
-
+            .filter(this::hasDeprecatedRole)
+            .forEach(this::removeDeprecatedRoles);
         return null;
     }
 
@@ -46,26 +44,19 @@ public class IdentityServiceMigrateCuratorHandler extends ApiGatewayHandler<Void
         return HttpURLConnection.HTTP_OK;
     }
     
-    private boolean userIsLegacyNviCurator(UserDto user) {
-        return user.getRoles().stream().map(RoleDto::getRoleName).anyMatch(DEPRECATED_NVI_CURATOR::equals);
+    private boolean hasDeprecatedRole(UserDto user) {
+        return user.getRoles().stream().map(RoleDto::getRoleName).anyMatch(RoleName::isDeprecated);
     }
 
-    private UserDto attemptUpdateRolesForUser(UserDto user) {
-        return attempt(() -> updateRolesForUser(user)).orElseThrow();
+    private void removeDeprecatedRoles(UserDto user) {
+        attempt(() -> updateRolesForUser(user)).orElseThrow();
+        logger.info("User roles has been updated: {}", user.getUsername());
     }
 
     private UserDto updateRolesForUser(UserDto user) throws NotFoundException {
-        logger.info("Updating nvi roles for {}", user.getUsername());
-        var roles = user.getRoles();
-        user.setRoles(updateRoleSet(roles));
-
+        var rolesToKeep = user.getRoles().stream().filter(RoleDto::isNotDeprecated).collect(Collectors.toSet());
+        user.setRoles(rolesToKeep);
         identityService.updateUser(user);
         return user;
-    }
-
-    private Set<RoleDto> updateRoleSet(Set<RoleDto> roleSet) {
-        roleSet.add(NVI_CURATOR_ROLE);
-        roleSet.removeIf(role -> DEPRECATED_NVI_CURATOR.equals(role.getRoleName()));
-        return roleSet;
     }
 }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/ListByInstitutionHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/ListByInstitutionHandler.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.database.IdentityServiceImpl;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.model.UserList;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -70,7 +71,7 @@ public class ListByInstitutionHandler extends ApiGatewayHandler<Void, UserList> 
     }
 
     private boolean hasOneRole(UserDto userDto, Set<String> checkedRoles) {
-        var userRoles = userDto.getRoles().stream().map(RoleDto::getRoleName).collect(Collectors.toSet());
+        var userRoles = userDto.getRoles().stream().map(RoleDto::getRoleName).map(RoleName::getValue).collect(Collectors.toSet());
         return !Collections.disjoint(userRoles, checkedRoles);
     }
 }

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/UpdateUserHandler.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/UpdateUserHandler.java
@@ -1,6 +1,5 @@
 package no.unit.nva.handlers;
 
-import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_AFFILIATION;
 import com.amazonaws.services.lambda.runtime.Context;
@@ -14,6 +13,7 @@ import no.unit.nva.database.IdentityService;
 import no.unit.nva.database.IdentityServiceImpl;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ForbiddenException;
@@ -80,7 +80,7 @@ public class UpdateUserHandler extends HandlerAccessingUser<UserDto, Void> {
         var newRoles = input.getRoles().stream().map(RoleDto::getRoleName).collect(Collectors.toSet());
         var existingRoles =
             databaseService.getUser(input).getRoles().stream().map(RoleDto::getRoleName).collect(Collectors.toSet());
-        return newRoles.contains(APP_ADMIN_ROLE_NAME) != existingRoles.contains(APP_ADMIN_ROLE_NAME);
+        return newRoles.contains(RoleName.APPLICATION_ADMIN) != existingRoles.contains(RoleName.APPLICATION_ADMIN);
     }
 
     private void validateRequest(UserDto input, RequestInfo requestInfo) throws InvalidInputException {

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/data/DefaultRoleSource.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/data/DefaultRoleSource.java
@@ -22,17 +22,6 @@ import no.unit.nva.useraccessservice.model.RoleName;
 
 public class DefaultRoleSource implements RoleSource {
 
-    protected static final String PUBLISHING_CURATOR_ROLE_NAME = "Publishing-Curator";
-    protected static final String DOI_CURATOR_ROLE_NAME = "Doi-Curator";
-    protected static final String NVI_CURATOR_ROLE_NAME = "Nvi-Curator";
-    protected static final String SUPPORT_CURATOR_ROLE_NAME = "Support-Curator";
-    protected static final String INSTITUTION_ADMIN_ROLE_NAME = "Institution-admin";
-    protected static final String INTERNAL_IMPORTER_ROLE_NAME = "Internal-importer";
-    protected static final String CURATOR_THESIS_ROLE_NAME = "Curator-thesis";
-    protected static final String CURATOR_THESIS_EMBARGO_ROLE_NAME = "Curator-thesis-embargo";
-    public static final String APP_ADMIN_ROLE_NAME = "App-admin";
-    protected static final String EDITOR_ROLE_NAME = "Editor";
-
     private static final RoleDto CREATOR_ROLE = RoleDto.newBuilder()
                                                     .withRoleName(RoleName.CREATOR)
                                                     .withAccessRights(List.of(MANAGE_OWN_RESOURCES))
@@ -83,7 +72,7 @@ public class DefaultRoleSource implements RoleSource {
                                                                    .build();
 
     private static final RoleDto APPLICATION_ADMIN_ROLE = RoleDto.newBuilder()
-                                                              .withRoleName(RoleName.SUPPORT_CURATOR)
+                                                              .withRoleName(RoleName.APPLICATION_ADMIN)
                                                               .withAccessRights(List.of(MANAGE_CUSTOMERS,
                                                                                         MANAGE_EXTERNAL_CLIENTS,
                                                                                         ACT_AS,

--- a/user-access-handlers/src/main/java/no/unit/nva/handlers/data/DefaultRoleSource.java
+++ b/user-access-handlers/src/main/java/no/unit/nva/handlers/data/DefaultRoleSource.java
@@ -1,6 +1,5 @@
 package no.unit.nva.handlers.data;
 
-import static no.unit.nva.database.IdentityService.Constants.ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT;
 import static nva.commons.apigateway.AccessRight.ACT_AS;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
@@ -19,6 +18,7 @@ import static nva.commons.apigateway.AccessRight.SUPPORT;
 import java.util.List;
 import no.unit.nva.handlers.RoleSource;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 
 public class DefaultRoleSource implements RoleSource {
 
@@ -34,56 +34,56 @@ public class DefaultRoleSource implements RoleSource {
     protected static final String EDITOR_ROLE_NAME = "Editor";
 
     private static final RoleDto CREATOR_ROLE = RoleDto.newBuilder()
-                                                    .withRoleName(ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT)
+                                                    .withRoleName(RoleName.CREATOR)
                                                     .withAccessRights(List.of(MANAGE_OWN_RESOURCES))
                                                     .build();
 
     public static final RoleDto PUBLISHING_CURATOR_ROLE = RoleDto.newBuilder()
-                                                    .withRoleName(PUBLISHING_CURATOR_ROLE_NAME)
+                                                    .withRoleName(RoleName.PUBLISHING_CURATOR)
                                                     .withAccessRights(List.of(MANAGE_RESOURCES_STANDARD,
                                                                               MANAGE_PUBLISHING_REQUESTS))
                                                     .build();
     public static final RoleDto NVI_CURATOR_ROLE = RoleDto.newBuilder()
-                                                   .withRoleName(NVI_CURATOR_ROLE_NAME)
+                                                   .withRoleName(RoleName.NVI_CURATOR)
                                                    .withAccessRights(List.of(MANAGE_RESOURCES_STANDARD,
                                                                              MANAGE_NVI_CANDIDATES))
                                                    .build();
     public static final RoleDto DOI_CURATOR_ROLE = RoleDto.newBuilder()
-                                                   .withRoleName(DOI_CURATOR_ROLE_NAME)
+                                                   .withRoleName(RoleName.DOI_CURATOR)
                                                    .withAccessRights(List.of(MANAGE_RESOURCES_STANDARD,
                                                                              MANAGE_DOI))
                                                    .build();
     public static final RoleDto SUPPORT_CURATOR_ROLE = RoleDto.newBuilder()
-                                                   .withRoleName(SUPPORT_CURATOR_ROLE_NAME)
+                                                   .withRoleName(RoleName.SUPPORT_CURATOR)
                                                    .withAccessRights(List.of(MANAGE_RESOURCES_STANDARD,
                                                                              SUPPORT))
                                                    .build();
     private static final RoleDto INSTITUTION_ADMIN_ROLE = RoleDto.newBuilder()
-                                                              .withRoleName(INSTITUTION_ADMIN_ROLE_NAME)
+                                                              .withRoleName(RoleName.INSTITUTION_ADMIN)
                                                               .withAccessRights(List.of(MANAGE_OWN_AFFILIATION))
                                                               .build();
 
     private static final RoleDto INTERNAL_IMPORTER = RoleDto.newBuilder()
-                                                                     .withRoleName(INTERNAL_IMPORTER_ROLE_NAME)
+                                                                     .withRoleName(RoleName.INTERNAL_IMPORTER)
                                                                      .withAccessRights(
                                                                          List.of(MANAGE_IMPORT))
                                                                      .build();
 
     private static final RoleDto CURATOR_THESIS_ROLE = RoleDto.newBuilder()
-                                                           .withRoleName(CURATOR_THESIS_ROLE_NAME)
+                                                           .withRoleName(RoleName.THESIS_CURATOR)
                                                            .withAccessRights(List.of(MANAGE_RESOURCES_STANDARD,
                                                                                      MANAGE_DEGREE))
                                                            .build();
 
     private static final RoleDto CURATOR_THESIS_EMBARGO_ROLE = RoleDto.newBuilder()
-                                                                   .withRoleName(CURATOR_THESIS_EMBARGO_ROLE_NAME)
+                                                                   .withRoleName(RoleName.EMBARGO_THESIS_CURATOR)
                                                                    .withAccessRights(
                                                                        List.of(MANAGE_RESOURCES_STANDARD,
                                                                                MANAGE_DEGREE_EMBARGO))
                                                                    .build();
 
     private static final RoleDto APPLICATION_ADMIN_ROLE = RoleDto.newBuilder()
-                                                              .withRoleName(APP_ADMIN_ROLE_NAME)
+                                                              .withRoleName(RoleName.SUPPORT_CURATOR)
                                                               .withAccessRights(List.of(MANAGE_CUSTOMERS,
                                                                                         MANAGE_EXTERNAL_CLIENTS,
                                                                                         ACT_AS,
@@ -92,7 +92,7 @@ public class DefaultRoleSource implements RoleSource {
                                                               .build();
 
     private static final RoleDto EDITOR_ROLE = RoleDto.newBuilder()
-                                                   .withRoleName(EDITOR_ROLE_NAME)
+                                                   .withRoleName(RoleName.EDITOR)
                                                    .withAccessRights(List.of(MANAGE_OWN_AFFILIATION,
                                                                              MANAGE_RESOURCES_ALL))
                                                    .build();

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
@@ -525,10 +525,6 @@ class CreateUserHandlerTest extends HandlerTest {
         return Set.of(role);
     }
 
-    private RoleName randomRoleName() {
-        return RoleName.values()[randomInteger(RoleName.values().length)];
-    }
-
     private Set<RoleDto> appAdminRole() {
         var role = RoleDto.newBuilder().withRoleName(RoleName.APPLICATION_ADMIN).build();
         addRoleToIdentityServiceBecauseNonExistingRolesAreIgnored(role);

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
@@ -67,7 +67,6 @@ import nva.commons.core.paths.UriWrapper;
 import nva.commons.secrets.SecretsReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -521,7 +520,7 @@ class CreateUserHandlerTest extends HandlerTest {
     }
 
     private Set<RoleDto> randomRoles() {
-        var role = RoleDto.newBuilder().withRoleName(randomRoleNameButNot(randomRoleName())).build();
+        var role = RoleDto.newBuilder().withRoleName(randomRoleNameButNot(RoleName.APPLICATION_ADMIN)).build();
         addRoleToIdentityServiceBecauseNonExistingRolesAreIgnored(role);
         return Set.of(role);
     }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/CreateUserHandlerTest.java
@@ -1,7 +1,8 @@
 package no.unit.nva.handlers;
 
+import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static no.unit.nva.useraccessservice.constants.ServiceConstants.API_DOMAIN;
@@ -37,18 +38,16 @@ import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import no.unit.nva.customer.testing.LocalCustomerServiceDatabase;
 import no.unit.nva.database.IdentityService;
-import no.unit.nva.database.IdentityServiceImpl;
 import no.unit.nva.database.LocalIdentityService;
-import no.unit.nva.database.RoleService;
 import no.unit.nva.handlers.models.CreateUserRequest;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.stubs.FakeSecretsManagerClient;
 import no.unit.nva.stubs.WiremockHttpClient;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessservice.constants.ServiceConstants;
-import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.model.ViewingScope;
 import no.unit.nva.useraccessservice.userceation.testing.cristin.AuthenticationScenarios;
@@ -62,13 +61,13 @@ import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.RequestInfoConstants;
 import nva.commons.apigateway.exceptions.ConflictException;
-import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.SingletonCollector;
 import nva.commons.core.attempt.Try;
 import nva.commons.core.paths.UriWrapper;
 import nva.commons.secrets.SecretsReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -522,37 +521,29 @@ class CreateUserHandlerTest extends HandlerTest {
     }
 
     private Set<RoleDto> randomRoles() {
-        var role = RoleDto.newBuilder().withRoleName(randomString()).build();
+        var role = RoleDto.newBuilder().withRoleName(randomRoleNameButNot(randomRoleName())).build();
         addRoleToIdentityServiceBecauseNonExistingRolesAreIgnored(role);
         return Set.of(role);
     }
 
+    private RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
+    }
+
     private Set<RoleDto> appAdminRole() {
-        var role = RoleDto.newBuilder().withRoleName(APP_ADMIN_ROLE_NAME).build();
+        var role = RoleDto.newBuilder().withRoleName(RoleName.APPLICATION_ADMIN).build();
         addRoleToIdentityServiceBecauseNonExistingRolesAreIgnored(role);
         return Set.of(role);
     }
 
     private void addRoleToIdentityServiceBecauseNonExistingRolesAreIgnored(RoleDto role) {
+        var existingRole = attempt(() -> identityService.getRole(role)).toOptional();
         try {
-            identityService.addRole(role);
+            if (existingRole.isEmpty()) {
+                identityService.addRole(role);
+            }
         } catch (ConflictException | InvalidInputException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private IdentityServiceImpl databaseServiceWithSyncDelay() {
-        return new IdentityServiceImpl(localDynamo) {
-            private int counter = 0;
-
-            @Override
-            public RoleDto getRole(RoleDto queryObject) throws InvalidEntryInternalException, NotFoundException {
-                if (counter == 0) {
-                    counter++;
-                    throw new NotFoundException(RoleService.ROLE_NOT_FOUND_MESSAGE);
-                }
-                return super.getRole(queryObject);
-            }
-        };
     }
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/EntityUtils.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/EntityUtils.java
@@ -10,13 +10,13 @@ import java.util.Set;
 import no.unit.nva.identityservice.json.JsonConfig;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.AccessRight;
 
 public final class EntityUtils {
 
     public static final String SOME_USERNAME = "SomeUsername";
-    public static final String SOME_ROLENAME = "SomeRole";
 
     public static final URI SOME_INSTITUTION = randomCristinOrgId();
     public static final String EMPTY_STRING = "";
@@ -59,7 +59,7 @@ public final class EntityUtils {
      */
     public static UserDto createUserWithRoleWithoutInstitution()
         throws InvalidEntryInternalException {
-        RoleDto sampleRole = createRole(SOME_ROLENAME);
+        RoleDto sampleRole = createRole(RoleName.CREATOR);
         return UserDto.newBuilder()
             .withUsername(SOME_USERNAME)
             .withGivenName(SOME_GIVEN_NAME)
@@ -71,14 +71,14 @@ public final class EntityUtils {
     /**
      * Creates a sample role.
      *
-     * @param someRole the role.
+     * @param roleName the role.
      * @return the role.
      * @throws InvalidEntryInternalException when generated role is invalid.
      */
-    public static RoleDto createRole(String someRole) throws InvalidEntryInternalException {
+    public static RoleDto createRole(RoleName roleName) throws InvalidEntryInternalException {
         return
             RoleDto.newBuilder()
-                .withRoleName(someRole)
+                .withRoleName(roleName)
                 .withAccessRights(SAMPLE_ACCESS_RIGHTS)
                 .build();
     }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/GetRoleHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/GetRoleHandlerTest.java
@@ -24,6 +24,7 @@ import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.ConflictException;
@@ -116,7 +117,7 @@ class GetRoleHandlerTest extends LocalIdentityService implements WithEnvironment
 
     private void addSampleRoleToDatabase()
         throws InvalidEntryInternalException, ConflictException, InvalidInputException {
-        RoleDto existingRole = RoleDto.newBuilder().withRoleName(GetRoleHandlerTest.THE_ROLE).build();
+        RoleDto existingRole = RoleDto.newBuilder().withRoleName(RoleName.CREATOR).build();
         databaseService.addRole(existingRole);
     }
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/GetRoleHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/GetRoleHandlerTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.handlers;
 
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -65,9 +66,9 @@ class GetRoleHandlerTest extends LocalIdentityService implements WithEnvironment
     void handleRequestReturnsRoleObjectWithTypeRole()
         throws ConflictException, InvalidEntryInternalException, InvalidInputException, IOException {
 
-        addSampleRoleToDatabase();
-
-        var request = queryWithRoleName();
+        var roleName = randomRoleName();
+        addSampleRoleToDatabase(roleName);
+        var request = queryWithRoleName(roleName);
         var response = sendRequest(request, RoleDto.class);
 
         var responseBody = JsonConfig.mapFrom(response.getBody());
@@ -84,19 +85,21 @@ class GetRoleHandlerTest extends LocalIdentityService implements WithEnvironment
     @Test
     void shouldReturnRoleDtoWhenARoleWithTheInputRoleNameExists()
         throws ApiGatewayException, IOException {
-        addSampleRoleToDatabase();
-        var request = queryWithRoleName();
+        var roleName = randomRoleName();
+        addSampleRoleToDatabase(roleName);
+        var request = queryWithRoleName(roleName);
         var response = sendRequest(request, RoleDto.class);
         var savedRole = RoleDto.fromJson(response.getBody());
-        assertThat(savedRole.getRoleName(), is(equalTo(THE_ROLE)));
+        assertThat(savedRole.getRoleName(), is(equalTo(roleName)));
     }
 
     @Test
     void shouldReturnNotFoundWhenThereIsNoRoleInTheDatabaseWithTheSpecifiedRoleName() throws IOException {
-        var requestInfo = queryWithRoleName();
+        var roleName = randomRoleName();
+        var requestInfo = queryWithRoleName(roleName);
         var response = sendRequest(requestInfo, Problem.class);
         var problem = response.getBodyObject(Problem.class);
-        assertThat(problem.getDetail(),containsString(THE_ROLE));
+        assertThat(problem.getDetail(),containsString(roleName.getValue()));
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
     }
 
@@ -109,15 +112,15 @@ class GetRoleHandlerTest extends LocalIdentityService implements WithEnvironment
         assertThat(response.getStatusCode(), is(equalTo(HttpStatus.SC_BAD_REQUEST)));
     }
 
-    private InputStream queryWithRoleName() throws JsonProcessingException {
+    private InputStream queryWithRoleName(RoleName roleName) throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
-            .withPathParameters(Map.of(GetRoleHandler.ROLE_PATH_PARAMETER, GetRoleHandlerTest.THE_ROLE))
+            .withPathParameters(Map.of(GetRoleHandler.ROLE_PATH_PARAMETER, roleName.getValue()))
             .build();
     }
 
-    private void addSampleRoleToDatabase()
+    private void addSampleRoleToDatabase(RoleName roleName)
         throws InvalidEntryInternalException, ConflictException, InvalidInputException {
-        RoleDto existingRole = RoleDto.newBuilder().withRoleName(RoleName.CREATOR).build();
+        RoleDto existingRole = RoleDto.newBuilder().withRoleName(roleName).build();
         databaseService.addRole(existingRole);
     }
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/HandlerTest.java
@@ -1,7 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import java.net.URI;
@@ -13,6 +13,7 @@ import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.ClientDto;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.exceptions.ConflictException;
 
@@ -48,12 +49,16 @@ public class HandlerTest extends LocalIdentityService {
     }
 
     protected UserDto createSampleUser(String username, URI institution) throws InvalidEntryInternalException {
-        RoleDto someRole = RoleDto.newBuilder().withRoleName(randomString()).build();
+        RoleDto someRole = RoleDto.newBuilder().withRoleName(randomRoleName()).build();
         return UserDto.newBuilder()
             .withUsername(username)
             .withRoles(Collections.singletonList(someRole))
             .withInstitution(institution)
             .build();
+    }
+
+    private RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 
     protected ClientDto insertClientToDatabase(ClientDto clientDto)

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceInitHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceInitHandlerTest.java
@@ -33,6 +33,7 @@ import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ConflictException;
@@ -44,11 +45,10 @@ import org.junit.jupiter.api.Test;
 
 class IdentityServiceInitHandlerTest {
 
-    private static final String ROLE_NAME = "My-role";
     private static final List<AccessRight> ACCESS_RIGHTS = List.of(MANAGE_DOI,
                                                                    MANAGE_PUBLISHING_REQUESTS);
     private static final RoleSource ROLE_SOURCE = () -> List.of(RoleDto.newBuilder()
-                                                                    .withRoleName(ROLE_NAME)
+                                                                    .withRoleName(RoleName.PUBLISHING_CURATOR)
                                                                     .withAccessRights(ACCESS_RIGHTS)
                                                                     .build());
 
@@ -111,7 +111,7 @@ class IdentityServiceInitHandlerTest {
 
     private RoleDto invalidRole() {
         var role = new RoleDto();
-        role.setRoleName("");
+        role.setRoleName(null);
         role.setAccessRights(Collections.emptyList());
         return role;
     }
@@ -120,7 +120,7 @@ class IdentityServiceInitHandlerTest {
     void shouldUpdateRoleIfAlreadyExists()
         throws InvalidInputException, ConflictException, IOException, NotFoundException {
         var role = RoleDto.newBuilder()
-                       .withRoleName(ROLE_NAME)
+                       .withRoleName(RoleName.DOI_CURATOR)
                        .withAccessRights(List.of(MANAGE_DOI))
                        .build();
         identityService.addRole(role);

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceInitHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceInitHandlerTest.java
@@ -48,7 +48,7 @@ class IdentityServiceInitHandlerTest {
     private static final List<AccessRight> ACCESS_RIGHTS = List.of(MANAGE_DOI,
                                                                    MANAGE_PUBLISHING_REQUESTS);
     private static final RoleSource ROLE_SOURCE = () -> List.of(RoleDto.newBuilder()
-                                                                    .withRoleName(RoleName.PUBLISHING_CURATOR)
+                                                                    .withRoleName(RoleName.DOI_CURATOR)
                                                                     .withAccessRights(ACCESS_RIGHTS)
                                                                     .build());
 

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandlerTest.java
@@ -20,6 +20,7 @@ import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.apigateway.exceptions.NotFoundException;
@@ -81,7 +82,7 @@ class IdentityServiceMigrateCuratorHandlerTest {
     @Test
     void shouldNotUpdateAlreadyMigratedUsers() throws InvalidInputException, ConflictException,
                                                       IOException, NotFoundException {
-        var randomRole = RoleDto.newBuilder().withRoleName(randomString()).build();
+        var randomRole = RoleDto.newBuilder().withRoleName(RoleName.EDITOR).build();
         var newRole = newNviCuratorRole();
         identityService.addRole(randomRole);
         identityService.addRole(newRole);
@@ -100,11 +101,11 @@ class IdentityServiceMigrateCuratorHandlerTest {
     }
 
     private RoleDto legacyNviCuratorRole() {
-        return RoleDto.newBuilder().withRoleName("Nvi-curator").build();
+        return RoleDto.newBuilder().withRoleName(RoleName.NVI_CURATOR).build();
     }
 
     private RoleDto newNviCuratorRole() {
-        return RoleDto.newBuilder().withRoleName("Nvi-Curator").build();
+        return RoleDto.newBuilder().withRoleName(RoleName.NVI_CURATOR).build();
     }
 
     private InputStream createRequest() throws com.fasterxml.jackson.core.JsonProcessingException {

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/IdentityServiceMigrateCuratorHandlerTest.java
@@ -101,7 +101,7 @@ class IdentityServiceMigrateCuratorHandlerTest {
     }
 
     private RoleDto legacyNviCuratorRole() {
-        return RoleDto.newBuilder().withRoleName(RoleName.NVI_CURATOR).build();
+        return RoleDto.newBuilder().withRoleName(RoleName.DEPRECATED_NVI_CURATOR).build();
     }
 
     private RoleDto newNviCuratorRole() {

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
@@ -2,7 +2,6 @@ package no.unit.nva.handlers;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static no.unit.nva.handlers.HandlerTest.DEFAULT_INSTITUTION;
 import static no.unit.nva.handlers.ListByInstitutionHandler.INSTITUTION_ID_QUERY_PARAMETER;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,12 +24,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import no.unit.nva.RandomUserDataGenerator;
 import no.unit.nva.stubs.FakeContext;
 import no.unit.nva.testutils.HandlerRequestBuilder;
-import no.unit.nva.testutils.RandomDataGenerator;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.model.UserList;
 import nva.commons.apigateway.GatewayResponse;
@@ -237,12 +235,12 @@ class ListByInstitutionHandlerTest extends HandlerTest {
                    .build();
     }
 
-    private InputStream createListWithFilterRequest(URI institutionId, List<String> roles)
+    private InputStream createListWithFilterRequest(URI institutionId, List<RoleName> roles)
         throws JsonProcessingException {
         var queryParams = Map.of(
             INSTITUTION_ID_QUERY_PARAMETER, institutionId.toString()
             );
-        var multiValueParams = Map.of(ROLE, roles);
+        var multiValueParams = Map.of(ROLE, roles.stream().map(RoleName::getValue).toList());
 
         return new HandlerRequestBuilder<>(dtoObjectMapper)
                    .withQueryParameters(queryParams)

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
@@ -1,6 +1,8 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.handlers.ListByInstitutionHandler.INSTITUTION_ID_QUERY_PARAMETER;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -35,6 +37,7 @@ import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ConflictException;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
@@ -81,7 +84,10 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     void handleRequestReturnsListOfUsersGivenAnInstitutionAndSingleRole()
         throws IOException, ConflictException, InvalidEntryInternalException {
 
-        var expectedUser = insertTwoUsersOfSameInstitution().getUsers().get(0);
+        var name = randomRoleName();
+        insertUserOfSameInstitution(DEFAULT_USERNAME, name);
+        var expectedUser =
+            insertUserOfSameInstitution(SOME_OTHER_USERNAME, randomRoleNameButNot(name)).getUsers().get(0);
         var roleName = ((RoleDto) expectedUser.getRoles().toArray()[0]).getRoleName();
         var validRequest = createListWithFilterRequest(DEFAULT_INSTITUTION, List.of(roleName));
 
@@ -218,6 +224,13 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     private void assertThatListsAreEquivalent(UserList expectedUsers, UserList actualUsers) {
         assertThat(actualUsers.getUsers(), containsInAnyOrder(expectedUsers.getUsers().toArray(UserDto[]::new)));
         assertThat(expectedUsers.getUsers(), containsInAnyOrder(actualUsers.getUsers().toArray()));
+    }
+
+    private UserList insertUserOfSameInstitution(String username, RoleName roleName)
+        throws InvalidEntryInternalException, ConflictException {
+        UserList users = new UserList();
+        users.getUsers().add(insertSampleUserToDatabase(username, DEFAULT_INSTITUTION, roleName));
+        return users;
     }
 
     private UserList insertTwoUsersOfSameInstitution()

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/ListByInstitutionHandlerTest.java
@@ -102,9 +102,9 @@ class ListByInstitutionHandlerTest extends HandlerTest {
     void handleRequestReturnsListOfUsersGivenAnInstitutionAndMultipleRoles()
         throws IOException, ConflictException, InvalidEntryInternalException {
 
-        var user1 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION);
-        var user2 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION);
-        var user3 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION);
+        var user1 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION, RoleName.SUPPORT_CURATOR);
+        var user2 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION, RoleName.SUPPORT_CURATOR);
+        var user3 = insertSampleUserToDatabase(randomString(), DEFAULT_INSTITUTION, RoleName.DOI_CURATOR);
 
         var rolesOfFirstTwoUsers = List.of(
             user1.getRoles().stream().findFirst().get().getRoleName(),

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
@@ -370,7 +370,7 @@ public class UpdateUserHandlerTest extends HandlerTest {
 
     private UserDto createUserUpdate(UserDto userDto) throws InvalidEntryInternalException {
         var anotherRoleName = userDto.getRoles().isEmpty()
-                                  ? randomRoleName()
+                                  ? randomRoleNameButNot(RoleName.APPLICATION_ADMIN)
                                   : randomRoleNameButNot(userDto.getRoles().iterator().next().getRoleName());
         var someOtherRole =
             RoleDto.newBuilder().withRoleName(anotherRoleName).build();

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.database.UserService.USER_NOT_FOUND_MESSAGE;
@@ -8,8 +9,7 @@ import static no.unit.nva.handlers.EntityUtils.createUserWithoutUsername;
 import static no.unit.nva.handlers.UpdateUserHandler.INCONSISTENT_USERNAME_IN_PATH_AND_OBJECT_ERROR;
 import static no.unit.nva.handlers.UpdateUserHandler.LOCATION_HEADER;
 import static no.unit.nva.handlers.UpdateUserHandler.USERNAME_PATH_PARAMETER;
-import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static no.unit.nva.useraccessservice.model.UserDto.VIEWING_SCOPE_FIELD;
 import static no.unit.nva.useraccessservice.model.ViewingScope.INCLUDED_UNITS;
@@ -38,6 +38,7 @@ import no.unit.nva.testutils.HandlerRequestBuilder;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -52,12 +53,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.zalando.problem.Problem;
 
 public class UpdateUserHandlerTest extends HandlerTest {
-    
-    public static final String SAMPLE_ROLE = "someRole";
+
     public static final String SAMPLE_USERNAME = "some@somewhere";
     public static final URI SAMPLE_INSTITUTION = randomCristinOrgId();
-    
-    public static final String ANOTHER_ROLE = "ANOTHER_ROLE";
     public static final String SOME_OTHER_USERNAME = "SomeOtherUsername";
     private IdentityServiceImpl databaseService;
     private Context context;
@@ -340,7 +338,7 @@ public class UpdateUserHandlerTest extends HandlerTest {
     }
     
     private UserDto sampleUser() throws InvalidEntryInternalException {
-        var someRole = RoleDto.newBuilder().withRoleName(SAMPLE_ROLE).build();
+        var someRole = RoleDto.newBuilder().withRoleName(RoleName.CREATOR).build();
         return UserDto.newBuilder()
             .withUsername(SAMPLE_USERNAME)
             .withInstitution(SAMPLE_INSTITUTION)
@@ -359,15 +357,23 @@ public class UpdateUserHandlerTest extends HandlerTest {
     }
 
     private static RoleDto getAppAdminRole() {
-        return RoleDto.newBuilder().withRoleName(APP_ADMIN_ROLE_NAME).build();
+        return RoleDto.newBuilder().withRoleName(RoleName.APPLICATION_ADMIN).build();
     }
 
     private static RoleDto getRandomRole() {
-        return RoleDto.newBuilder().withRoleName(randomString()).build();
+        return RoleDto.newBuilder().withRoleName(randomRoleName()).build();
+    }
+
+    private static RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 
     private UserDto createUserUpdate(UserDto userDto) throws InvalidEntryInternalException {
-        var someOtherRole = RoleDto.newBuilder().withRoleName(ANOTHER_ROLE).build();
+        var anotherRoleName = userDto.getRoles().isEmpty()
+                                  ? randomRoleName()
+                                  : randomRoleNameButNot(userDto.getRoles().iterator().next().getRoleName());
+        var someOtherRole =
+            RoleDto.newBuilder().withRoleName(anotherRoleName).build();
         return userDto.copy()
             .withRoles(Collections.singletonList(someOtherRole))
             .withViewingScope(randomViewingScope())

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.handlers;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
@@ -362,10 +363,6 @@ public class UpdateUserHandlerTest extends HandlerTest {
 
     private static RoleDto getRandomRole() {
         return RoleDto.newBuilder().withRoleName(randomRoleName()).build();
-    }
-
-    private static RoleName randomRoleName() {
-        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 
     private UserDto createUserUpdate(UserDto userDto) throws InvalidEntryInternalException {

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/UpdateUserHandlerTest.java
@@ -48,6 +48,7 @@ import nva.commons.apigateway.exceptions.NotFoundException;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -362,7 +363,7 @@ public class UpdateUserHandlerTest extends HandlerTest {
     }
 
     private static RoleDto getRandomRole() {
-        return RoleDto.newBuilder().withRoleName(randomRoleName()).build();
+        return RoleDto.newBuilder().withRoleName(randomRoleNameButNot(RoleName.APPLICATION_ADMIN)).build();
     }
 
     private UserDto createUserUpdate(UserDto userDto) throws InvalidEntryInternalException {

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/data/DefaultRoleSourceTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/data/DefaultRoleSourceTest.java
@@ -1,13 +1,12 @@
 package no.unit.nva.handlers.data;
 
-import static no.unit.nva.database.IdentityService.Constants.ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT;
 import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.DOI_CURATOR_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.INTERNAL_IMPORTER_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.CURATOR_THESIS_EMBARGO_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.CURATOR_THESIS_ROLE_NAME;
+import static no.unit.nva.handlers.data.DefaultRoleSource.DOI_CURATOR_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.EDITOR_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.INSTITUTION_ADMIN_ROLE_NAME;
+import static no.unit.nva.handlers.data.DefaultRoleSource.INTERNAL_IMPORTER_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.NVI_CURATOR_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.PUBLISHING_CURATOR_ROLE_NAME;
 import static no.unit.nva.handlers.data.DefaultRoleSource.SUPPORT_CURATOR_ROLE_NAME;
@@ -32,6 +31,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import java.util.List;
 import no.unit.nva.handlers.RoleSource;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.core.SingletonCollector;
 import org.junit.jupiter.api.Test;
 
@@ -45,14 +45,14 @@ public class DefaultRoleSourceTest {
 
     @Test
     void creatorsShouldHaveCorrectAccessRights() {
-        var creatorRole = getRoleByName(ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT);
+        var creatorRole = getRoleByName(RoleName.CREATOR);
 
         assertThat(creatorRole.getAccessRights(), containsInAnyOrder(MANAGE_OWN_RESOURCES));
     }
 
     @Test
     void doiCuratorsShouldHaveCorrectAccessRights() {
-        var curatorRole = getRoleByName(DOI_CURATOR_ROLE_NAME);
+        var curatorRole = getRoleByName(RoleName.DOI_CURATOR);
 
         assertThat(curatorRole.getAccessRights(), containsInAnyOrder(MANAGE_DOI,
                                                                      MANAGE_RESOURCES_STANDARD));
@@ -60,7 +60,7 @@ public class DefaultRoleSourceTest {
 
     @Test
     void supportCuratorsShouldHaveCorrectAccessRights() {
-        var curatorRole = getRoleByName(SUPPORT_CURATOR_ROLE_NAME);
+        var curatorRole = getRoleByName(RoleName.SUPPORT_CURATOR);
 
         assertThat(curatorRole.getAccessRights(), containsInAnyOrder(SUPPORT,
                                                                      MANAGE_RESOURCES_STANDARD));
@@ -68,7 +68,7 @@ public class DefaultRoleSourceTest {
 
     @Test
     void publishingCuratorsShouldHaveCorrectAccessRights() {
-        var curatorRole = getRoleByName(PUBLISHING_CURATOR_ROLE_NAME);
+        var curatorRole = getRoleByName(RoleName.PUBLISHING_CURATOR);
 
         assertThat(curatorRole.getAccessRights(), containsInAnyOrder(MANAGE_PUBLISHING_REQUESTS,
                                                                      MANAGE_RESOURCES_STANDARD));
@@ -76,7 +76,7 @@ public class DefaultRoleSourceTest {
 
     @Test
     void nviCuratorsShouldHaveCorrectAccessRights() {
-        var curatorRole = getRoleByName(NVI_CURATOR_ROLE_NAME);
+        var curatorRole = getRoleByName(RoleName.NVI_CURATOR);
 
         assertThat(curatorRole.getAccessRights(), containsInAnyOrder(MANAGE_NVI_CANDIDATES,
                                                                      MANAGE_RESOURCES_STANDARD));
@@ -84,21 +84,21 @@ public class DefaultRoleSourceTest {
 
     @Test
     void importCandidateCuratorsShouldHaveCorrectAccessRights() {
-        var importCandidateCuratorRole = getRoleByName(INTERNAL_IMPORTER_ROLE_NAME);
+        var importCandidateCuratorRole = getRoleByName(RoleName.INTERNAL_IMPORTER);
 
         assertThat(importCandidateCuratorRole.getAccessRights(), containsInAnyOrder(MANAGE_IMPORT));
     }
 
     @Test
     void thesisCuratorsShouldHaveCorrectAccessRights() {
-        var thesisCuratorRole = getRoleByName(CURATOR_THESIS_ROLE_NAME);
+        var thesisCuratorRole = getRoleByName(RoleName.THESIS_CURATOR);
 
         assertThat(thesisCuratorRole.getAccessRights(), containsInAnyOrder(MANAGE_RESOURCES_STANDARD, MANAGE_DEGREE));
     }
 
     @Test
     void thesisEmbargoCuratorsShouldHaveCorrectAccessRights() {
-        var thesisEmbargoCuratorRole = getRoleByName(CURATOR_THESIS_EMBARGO_ROLE_NAME);
+        var thesisEmbargoCuratorRole = getRoleByName(RoleName.EMBARGO_THESIS_CURATOR);
 
         assertThat(thesisEmbargoCuratorRole.getAccessRights(), containsInAnyOrder(MANAGE_RESOURCES_STANDARD,
                                                                                   MANAGE_DEGREE_EMBARGO));
@@ -106,14 +106,14 @@ public class DefaultRoleSourceTest {
 
     @Test
     void institutionAdminsShouldHaveCorrectAccessRights() {
-        var institutionAdminRole = getRoleByName(INSTITUTION_ADMIN_ROLE_NAME);
+        var institutionAdminRole = getRoleByName(RoleName.INSTITUTION_ADMIN);
 
         assertThat(institutionAdminRole.getAccessRights(), containsInAnyOrder(MANAGE_OWN_AFFILIATION));
     }
 
     @Test
     void appAdminsShouldHaveCorrectAccessRights() {
-        var appAdminRole = getRoleByName(APP_ADMIN_ROLE_NAME);
+        var appAdminRole = getRoleByName(RoleName.APPLICATION_ADMIN);
 
         assertThat(appAdminRole.getAccessRights(), containsInAnyOrder(MANAGE_CUSTOMERS,
                                                                       MANAGE_EXTERNAL_CLIENTS,
@@ -124,7 +124,7 @@ public class DefaultRoleSourceTest {
 
     @Test
     void editorsShouldHaveCorrectAccessRights() {
-        var editorRole = getRoleByName(EDITOR_ROLE_NAME);
+        var editorRole = getRoleByName(RoleName.EDITOR);
 
         assertThat(editorRole.getAccessRights(), containsInAnyOrder(MANAGE_OWN_AFFILIATION,
                                                                     MANAGE_RESOURCES_ALL));
@@ -132,7 +132,7 @@ public class DefaultRoleSourceTest {
 
     @Test
     void shouldReturnExpectedNumberOfRoles() {
-        var expectedNumberOfRoles = List.of(ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT,
+        var expectedNumberOfRoles = List.of(RoleName.CREATOR,
                                             NVI_CURATOR_ROLE_NAME,
                                             DOI_CURATOR_ROLE_NAME,
                                             SUPPORT_CURATOR_ROLE_NAME,
@@ -147,9 +147,9 @@ public class DefaultRoleSourceTest {
         assertThat(roleSource.roles(), hasSize(expectedNumberOfRoles));
     }
 
-    private RoleDto getRoleByName(String roleName) {
+    private RoleDto getRoleByName(RoleName roleName) {
         return roleSource.roles().stream()
-                   .filter(role -> roleName.equals(role.getRoleName()))
+                   .filter(role -> role.getRoleName().equals(roleName))
                    .collect(SingletonCollector.collect());
     }
 }

--- a/user-access-handlers/src/test/java/no/unit/nva/handlers/data/DefaultRoleSourceTest.java
+++ b/user-access-handlers/src/test/java/no/unit/nva/handlers/data/DefaultRoleSourceTest.java
@@ -1,15 +1,5 @@
 package no.unit.nva.handlers.data;
 
-import static no.unit.nva.handlers.data.DefaultRoleSource.APP_ADMIN_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.CURATOR_THESIS_EMBARGO_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.CURATOR_THESIS_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.DOI_CURATOR_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.EDITOR_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.INSTITUTION_ADMIN_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.INTERNAL_IMPORTER_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.NVI_CURATOR_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.PUBLISHING_CURATOR_ROLE_NAME;
-import static no.unit.nva.handlers.data.DefaultRoleSource.SUPPORT_CURATOR_ROLE_NAME;
 import static nva.commons.apigateway.AccessRight.ACT_AS;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_DEGREE;
@@ -133,16 +123,16 @@ public class DefaultRoleSourceTest {
     @Test
     void shouldReturnExpectedNumberOfRoles() {
         var expectedNumberOfRoles = List.of(RoleName.CREATOR,
-                                            NVI_CURATOR_ROLE_NAME,
-                                            DOI_CURATOR_ROLE_NAME,
-                                            SUPPORT_CURATOR_ROLE_NAME,
-                                            PUBLISHING_CURATOR_ROLE_NAME,
-                                            CURATOR_THESIS_ROLE_NAME,
-                                            CURATOR_THESIS_EMBARGO_ROLE_NAME,
-                                            INTERNAL_IMPORTER_ROLE_NAME,
-                                            INSTITUTION_ADMIN_ROLE_NAME,
-                                            APP_ADMIN_ROLE_NAME,
-                                            EDITOR_ROLE_NAME).size();
+                                            RoleName.NVI_CURATOR,
+                                            RoleName.DOI_CURATOR,
+                                            RoleName.SUPPORT_CURATOR,
+                                            RoleName.PUBLISHING_CURATOR,
+                                            RoleName.THESIS_CURATOR,
+                                            RoleName.EMBARGO_THESIS_CURATOR,
+                                            RoleName.INTERNAL_IMPORTER,
+                                            RoleName.INSTITUTION_ADMIN,
+                                            RoleName.APPLICATION_ADMIN,
+                                            RoleName.EDITOR).size();
 
         assertThat(roleSource.roles(), hasSize(expectedNumberOfRoles));
     }

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleDb.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleDb.java
@@ -12,10 +12,10 @@ import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.interfaces.Typed;
 import no.unit.nva.useraccessservice.interfaces.WithCopy;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
-import nva.commons.core.attempt.Try;
 import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
@@ -33,7 +33,7 @@ public class RoleDb implements DynamoEntryWithRangeKey, WithCopy<Builder>, Typed
     public static final String TYPE_VALUE = "ROLE";
     public static final TableSchema<RoleDb> TABLE_SCHEMA = TableSchema.fromBean(RoleDb.class);
     private Set<AccessRight> accessRights;
-    private String name;
+    private RoleName name;
 
     public RoleDb() {
         super();
@@ -66,12 +66,12 @@ public class RoleDb implements DynamoEntryWithRangeKey, WithCopy<Builder>, Typed
 
     @JacocoGenerated
     @DynamoDbAttribute(NAME_FIELD)
-    public String getName() {
+    public RoleName getName() {
         return name;
     }
 
     @JacocoGenerated
-    public void setName(String name) {
+    public void setName(RoleName name) {
         this.name = name;
     }
 
@@ -92,7 +92,7 @@ public class RoleDb implements DynamoEntryWithRangeKey, WithCopy<Builder>, Typed
     @DynamoDbPartitionKey
     @DynamoDbAttribute(PRIMARY_KEY_HASH_KEY)
     public String getPrimaryKeyHashKey() {
-        return this.getType() + FIELD_DELIMITER + getName();
+        return this.getType() + FIELD_DELIMITER + getName().getValue();
     }
 
     @Override
@@ -151,26 +151,24 @@ public class RoleDb implements DynamoEntryWithRangeKey, WithCopy<Builder>, Typed
     }
 
     public RoleDto toRoleDto() {
-
-        return Try.attempt(() -> RoleDto.newBuilder()
+        return RoleDto.newBuilder()
                 .withRoleName(this.getName())
                 .withAccessRights(getAccessRights())
-                .build())
-            .orElseThrow(fail -> new InvalidEntryInternalException(fail.getException()));
+                .build();
     }
 
     public static class Builder {
 
         public static final String EMPTY_ROLE_NAME_ERROR = "Rolename cannot be null or blank";
-        private String name;
+        private RoleName name;
         private Set<AccessRight> accessRights;
 
         protected Builder() {
             accessRights = Collections.emptySet();
         }
 
-        public Builder withName(String val) {
-            name = val;
+        public Builder withName(RoleName name) {
+            this.name = name;
             return this;
         }
 
@@ -180,7 +178,7 @@ public class RoleDb implements DynamoEntryWithRangeKey, WithCopy<Builder>, Typed
         }
 
         public RoleDb build() {
-            if (StringUtils.isNotBlank(name)) {
+            if (nonNull(name) && StringUtils.isNotBlank(name.getValue())) {
                 return new RoleDb(this);
             }
             throw new InvalidEntryInternalException(EMPTY_ROLE_NAME_ERROR);

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
@@ -1,7 +1,9 @@
 package no.unit.nva.useraccessservice.dao;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
+import nva.commons.core.JacocoGenerated;
 
 public enum RoleName {
 
@@ -15,7 +17,11 @@ public enum RoleName {
     EMBARGO_THESIS_CURATOR("Curator-thesis-embargo"),
     APPLICATION_ADMIN("App-admin"),
     EDITOR("Editor"),
-    CREATOR("Creator");
+    CREATOR("Creator"),
+    @Deprecated
+    DEPRECATED_NVI_CURATOR("Nvi-curator"),
+    @Deprecated
+    DEPRECATED_CURATOR("Curator");
 
     private final String value;
 
@@ -39,5 +45,11 @@ public enum RoleName {
     @Override
     public String toString() {
         return value;
+    }
+
+    @JacocoGenerated
+    @JsonIgnore
+    public boolean isDeprecated() {
+        return this.equals(DEPRECATED_NVI_CURATOR) || this.equals(DEPRECATED_CURATOR);
     }
 }

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
@@ -21,7 +21,9 @@ public enum RoleName {
     @Deprecated
     DEPRECATED_NVI_CURATOR("Nvi-curator"),
     @Deprecated
-    DEPRECATED_CURATOR("Curator");
+    DEPRECATED_CURATOR("Curator"),
+    @Deprecated
+    DEPRECATED_INTERNAL_IMPORT("Curator-Import-candidate");
 
     private final String value;
 
@@ -50,6 +52,8 @@ public enum RoleName {
     @JacocoGenerated
     @JsonIgnore
     public boolean isDeprecated() {
-        return this.equals(DEPRECATED_NVI_CURATOR) || this.equals(DEPRECATED_CURATOR);
+        return this.equals(DEPRECATED_NVI_CURATOR)
+               || this.equals(DEPRECATED_CURATOR)
+               || this.equals(DEPRECATED_INTERNAL_IMPORT);
     }
 }

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
@@ -1,0 +1,38 @@
+package no.unit.nva.useraccessservice.dao;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+public enum RoleName {
+
+    PUBLISHING_CURATOR("Publishing-Curator"),
+    DOI_CURATOR("Doi-Curator"),
+    NVI_CURATOR("Nvi-Curator"),
+    SUPPORT_CURATOR("Support-Curator"),
+    INSTITUTION_ADMIN("Institution-admin"),
+    INTERNAL_IMPORTER("Internal-importer"),
+    THESIS_CURATOR("Curator-thesis"),
+    EMBARGO_THESIS_CURATOR("Curator-thesis-embargo"),
+    APPLICATION_ADMIN("App-admin"),
+    EDITOR("Editor"),
+    CREATOR("Creator");
+
+    private final String value;
+
+    RoleName(String value) {
+
+        this.value = value;
+    }
+
+    public static RoleName fromValue(String value) {
+        return Arrays.stream(RoleName.values())
+                   .filter(entry -> entry.getValue().equals(value))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
+++ b/user-access-internal-model/src/main/java/no/unit/nva/useraccessservice/dao/RoleName.java
@@ -35,4 +35,9 @@ public enum RoleName {
     public String getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return value;
+    }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/DynamoEntryWithRangeKeyTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/DynamoEntryWithRangeKeyTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.useraccessservice.dao;
 
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -13,7 +14,7 @@ class DynamoEntryWithRangeKeyTest {
 
     @Test
     void setTypeHasNoEffect() throws InvalidEntryInternalException {
-        RoleDb roleDbEntry = RoleDb.newBuilder().withName("SomeName").build();
+        RoleDb roleDbEntry = RoleDb.newBuilder().withName(randomRoleName()).build();
         RoleDb copy = roleDbEntry.copy().build();
         copy.setType(SOME_TYPE);
 
@@ -22,7 +23,7 @@ class DynamoEntryWithRangeKeyTest {
 
     @Test
     void setPrimaryRangeKeyIsNotActivatedWhenRangeKeyHasBeenSet() throws InvalidEntryInternalException {
-        RoleDb roleDbEntry = RoleDb.newBuilder().withName("SomeName").build();
+        RoleDb roleDbEntry = RoleDb.newBuilder().withName(randomRoleName()).build();
         RoleDb copy = roleDbEntry.copy().build();
         copy.setPrimaryKeyRangeKey(SOME_INVALID_KEY);
         assertThat(copy, is(equalTo(roleDbEntry)));

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/EntityUtils.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/EntityUtils.java
@@ -1,18 +1,19 @@
 package no.unit.nva.useraccessservice.dao;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Set;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.AccessRight;
 
 public final class EntityUtils {
 
     public static final String SOME_USERNAME = "SomeUsername";
-    public static final String SOME_ROLENAME = "SomeRole";
     public static final URI SOME_INSTITUTION = randomCristinOrgId();
 
     public static final Set<AccessRight> SAMPLE_ACCESS_RIGHTS =
@@ -35,7 +36,7 @@ public final class EntityUtils {
      * @return {@link UserDto}
      */
     public static UserDto createUserWithRoleWithoutInstitution() {
-        RoleDto sampleRole = createRole(SOME_ROLENAME);
+        RoleDto sampleRole = createRole(randomRoleName());
         return UserDto.newBuilder()
             .withUsername(SOME_USERNAME)
             .withGivenName(SOME_GIVEN_NAME)
@@ -47,13 +48,17 @@ public final class EntityUtils {
     /**
      * Creates a sample role.
      *
-     * @param someRole the role name.
+     * @param roleName the role name.
      * @return the sample role.
      */
-    public static RoleDto createRole(String someRole) {
+    public static RoleDto createRole(RoleName roleName) {
         return RoleDto.newBuilder()
-            .withRoleName(someRole)
+            .withRoleName(roleName)
             .withAccessRights(SAMPLE_ACCESS_RIGHTS)
             .build();
+    }
+
+    private static RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/EntityUtils.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/EntityUtils.java
@@ -1,6 +1,7 @@
 package no.unit.nva.useraccessservice.dao;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import java.net.URI;
@@ -56,9 +57,5 @@ public final class EntityUtils {
             .withRoleName(roleName)
             .withAccessRights(SAMPLE_ACCESS_RIGHTS)
             .build();
-    }
-
-    private static RoleName randomRoleName() {
-        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.useraccessservice.dao;
 
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -122,15 +123,6 @@ public class RoleDbTest {
         assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(RoleDb.TYPE_VALUE));
     }
 
-//    @ParameterizedTest(name = "setPrimaryHashKey throws exception when input is:\"{0}\"")
-//    @NullAndEmptySource
-//    @ValueSource(strings = {" ", "\t", "\n", "\r"})
-//    void setPrimaryHashKeyThrowsExceptionWhenInputIsBlankOrNullString(String blankString) {
-//        Executable action = () -> RoleDb.newBuilder().withName(blankString).build();
-//        InvalidEntryInternalException exception = assertThrows(InvalidEntryInternalException.class, action);
-//        assertThat(exception.getMessage(), containsString(EMPTY_ROLE_NAME_ERROR));
-//    }
-
     @Test
     void setPrimaryRangeKeyHasNoEffect() throws InvalidEntryInternalException {
         RoleDb originalRole = RoleDb.newBuilder().withName(randomRoleName()).build();
@@ -169,9 +161,5 @@ public class RoleDbTest {
             .withName(RoleName.fromValue(roleNameValue))
             .withAccessRights(accessRights)
             .build();
-    }
-
-    private RoleName randomRoleName() {
-        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.useraccessservice.dao;
 
 import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -20,6 +21,7 @@ import java.util.Set;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.AccessRight;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -62,7 +64,7 @@ public class RoleDbTest {
     @Test
     void equalsReturnsFalseWhenNameIsDifferent() throws InvalidEntryInternalException {
         RoleDb left = sampleRole;
-        RoleDb right = sampleRole.copy().withName(RoleName.PUBLISHING_CURATOR).build();
+        RoleDb right = sampleRole.copy().withName(randomRoleNameButNot(sampleRole.getName())).build();
         assertThat(left, is(not(equalTo(right))));
     }
 

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleDbTest.java
@@ -1,8 +1,7 @@
 package no.unit.nva.useraccessservice.dao;
 
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.useraccessservice.dao.RoleDb.Builder.EMPTY_ROLE_NAME_ERROR;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -18,20 +17,17 @@ import java.beans.Introspector;
 import java.util.Collections;
 import java.util.Set;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessservice.model.RoleName;
 import nva.commons.apigateway.AccessRight;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class RoleDbTest {
 
-    public static final String SOME_ROLE_NAME = "someRoleName";
     public static final String SOME_OTHER_RANGE_KEY = "SomeOtherRangeKey";
     public static final String SOME_TYPE = "SomeType";
     public static final RoleSetConverter ROLE_SET_CONVERTER = new RoleSetConverter();
-    private final RoleDb sampleRole = createSampleRole();
+    private final RoleDb sampleRole = createSampleRole(randomRoleName().getValue());
 
     public RoleDbTest() throws InvalidEntryInternalException {
     }
@@ -43,7 +39,7 @@ public class RoleDbTest {
 
     @Test
     public void objectIsStoredWithType() throws IntrospectionException {
-        var role = RoleDb.newBuilder().withName(randomString()).build();
+        var role = RoleDb.newBuilder().withName(randomRoleName()).build();
         var beanInfo = Introspector.getBeanInfo(RoleDb.class);
         var item = RoleDb.TABLE_SCHEMA.itemToMap(role, true);
         assertThat(item.get(RoleDb.TYPE_FIELD), is(not(nullValue())));
@@ -65,7 +61,7 @@ public class RoleDbTest {
     @Test
     void equalsReturnsFalseWhenNameIsDifferent() throws InvalidEntryInternalException {
         RoleDb left = sampleRole;
-        RoleDb right = sampleRole.copy().withName("SomeOtherName").build();
+        RoleDb right = sampleRole.copy().withName(RoleName.PUBLISHING_CURATOR).build();
         assertThat(left, is(not(equalTo(right))));
     }
 
@@ -87,19 +83,21 @@ public class RoleDbTest {
 
     @Test
     void roleDbHasRoleName() throws InvalidEntryInternalException {
-        RoleDb roleDbEntry = createSampleRole();
-        assertThat(roleDbEntry.getName(), is(equalTo(SOME_ROLE_NAME)));
+        var roleNameValue = randomRoleName().getValue();
+        RoleDb roleDbEntry = createSampleRole(roleNameValue);
+        assertThat(roleDbEntry.getName().getValue(), is(equalTo(roleNameValue)));
     }
 
     @Test
     void builderSetsTheRolename() throws InvalidEntryInternalException {
-        RoleDb role = RoleDb.newBuilder().withName(SOME_ROLE_NAME).build();
-        assertThat(role.getName(), is(equalTo(SOME_ROLE_NAME)));
+        var name = randomRoleName();
+        RoleDb role = RoleDb.newBuilder().withName(name).build();
+        assertThat(role.getName(), is(equalTo(name)));
     }
 
     @Test
     void buildReturnsObjectWithInitializedPrimaryHashKey() throws InvalidEntryInternalException {
-        RoleDb role = RoleDb.newBuilder().withName(SOME_ROLE_NAME).build();
+        RoleDb role = RoleDb.newBuilder().withName(randomRoleName()).build();
         assertThat(role.getPrimaryKeyHashKey(), is(not(nullValue())));
         assertThat(role.getPrimaryKeyHashKey(), is(not(emptyString())));
     }
@@ -112,7 +110,7 @@ public class RoleDbTest {
 
     @Test
     void getPrimaryHashKeyReturnsStringContainingRoleName() {
-        assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(sampleRole.getName()));
+        assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(sampleRole.getName().getValue()));
     }
 
     @Test
@@ -120,22 +118,22 @@ public class RoleDbTest {
         String someOtherHashKey = "SomeOtherHashKey";
         sampleRole.setPrimaryKeyHashKey(someOtherHashKey);
         assertThat(sampleRole.getPrimaryKeyHashKey(), is(not(equalTo(someOtherHashKey))));
-        assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(sampleRole.getName()));
+        assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(sampleRole.getName().getValue()));
         assertThat(sampleRole.getPrimaryKeyHashKey(), containsString(RoleDb.TYPE_VALUE));
     }
 
-    @ParameterizedTest(name = "setPrimaryHashKey throws exception when input is:\"{0}\"")
-    @NullAndEmptySource
-    @ValueSource(strings = {" ", "\t", "\n", "\r"})
-    void setPrimaryHashKeyThrowsExceptionWhenInputIsBlankOrNullString(String blankString) {
-        Executable action = () -> RoleDb.newBuilder().withName(blankString).build();
-        InvalidEntryInternalException exception = assertThrows(InvalidEntryInternalException.class, action);
-        assertThat(exception.getMessage(), containsString(EMPTY_ROLE_NAME_ERROR));
-    }
+//    @ParameterizedTest(name = "setPrimaryHashKey throws exception when input is:\"{0}\"")
+//    @NullAndEmptySource
+//    @ValueSource(strings = {" ", "\t", "\n", "\r"})
+//    void setPrimaryHashKeyThrowsExceptionWhenInputIsBlankOrNullString(String blankString) {
+//        Executable action = () -> RoleDb.newBuilder().withName(blankString).build();
+//        InvalidEntryInternalException exception = assertThrows(InvalidEntryInternalException.class, action);
+//        assertThat(exception.getMessage(), containsString(EMPTY_ROLE_NAME_ERROR));
+//    }
 
     @Test
     void setPrimaryRangeKeyHasNoEffect() throws InvalidEntryInternalException {
-        RoleDb originalRole = RoleDb.newBuilder().withName(SOME_ROLE_NAME).build();
+        RoleDb originalRole = RoleDb.newBuilder().withName(randomRoleName()).build();
         RoleDb copy = originalRole.copy().build();
         copy.setPrimaryKeyRangeKey(SOME_OTHER_RANGE_KEY);
         assertThat(originalRole, is(equalTo(copy)));
@@ -143,7 +141,7 @@ public class RoleDbTest {
 
     @Test
     void setTypeHasNoEffect() throws InvalidEntryInternalException {
-        RoleDb originalRole = RoleDb.newBuilder().withName(SOME_ROLE_NAME).build();
+        RoleDb originalRole = RoleDb.newBuilder().withName(randomRoleName()).build();
         RoleDb copy = originalRole.copy().build();
         copy.setType(SOME_TYPE);
         assertThat(originalRole, is(equalTo(copy)));
@@ -165,11 +163,15 @@ public class RoleDbTest {
         assertThat(actual, is(equalTo(expected)));
     }
 
-    private RoleDb createSampleRole() throws InvalidEntryInternalException {
+    private RoleDb createSampleRole(String roleNameValue) throws InvalidEntryInternalException {
         Set<AccessRight> accessRights = Collections.singleton(AccessRight.MANAGE_DOI);
         return RoleDb.newBuilder()
-            .withName(SOME_ROLE_NAME)
+            .withName(RoleName.fromValue(roleNameValue))
             .withAccessRights(accessRights)
             .build();
+    }
+
+    private RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 }

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleNameTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/RoleNameTest.java
@@ -1,0 +1,14 @@
+package no.unit.nva.useraccessservice.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class RoleNameTest {
+
+    @ParameterizedTest
+    @EnumSource(RoleName.class)
+    void shouldConvertStringToRoleNameEnum(RoleName roleName) {
+        assertEquals(roleName, RoleName.fromValue(roleName.getValue()));
+    }
+}

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/UserDaoTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/UserDaoTest.java
@@ -1,6 +1,7 @@
 package no.unit.nva.useraccessservice.dao;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -17,7 +18,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.exceptions.BadRequestException;
@@ -174,42 +175,42 @@ class UserDaoTest {
         assertThat(converted, doesNotHaveEmptyValues());
     }
 
-    @ParameterizedTest(name = "fromUserDb throws Exception user contains invalidRole. Rolename:\"{0}\"")
-    @NullAndEmptySource
-    void fromUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
-        throws InvalidEntryInternalException {
-        RoleDb invalidRole = new RoleDb();
-        invalidRole.setName(invalidRoleName);
-        List<RoleDb> invalidRoles = Collections.singletonList(invalidRole);
-        UserDao userDaoWithInvalidRole = UserDao.newBuilder()
-            .withUsername(SOME_USERNAME)
-            .withRoles(invalidRoles)
-            .build();
+//    @ParameterizedTest(name = "fromUserDb throws Exception user contains invalidRole. Rolename:\"{0}\"")
+//    @NullAndEmptySource
+//    void fromUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
+//        throws InvalidEntryInternalException {
+//        RoleDb invalidRole = new RoleDb();
+//        invalidRole.setName(invalidRoleName);
+//        List<RoleDb> invalidRoles = Collections.singletonList(invalidRole);
+//        UserDao userDaoWithInvalidRole = UserDao.newBuilder()
+//            .withUsername(SOME_USERNAME)
+//            .withRoles(invalidRoles)
+//            .build();
+//
+//        Executable action = userDaoWithInvalidRole::toUserDto;
+//        RuntimeException exception = assertThrows(RuntimeException.class, action);
+//        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
+//    }
 
-        Executable action = userDaoWithInvalidRole::toUserDto;
-        RuntimeException exception = assertThrows(RuntimeException.class, action);
-        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    void toUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
-        throws InvalidEntryInternalException {
-        RoleDto invalidRole = RoleDto.newBuilder().withRoleName(SOME_ROLENAME).build();
-        invalidRole.setRoleName(invalidRoleName);
-        List<RoleDto> invalidRoles = Collections.singletonList(invalidRole);
-        UserDto userWithInvalidRole = UserDto.newBuilder().withUsername(SOME_USERNAME).withRoles(invalidRoles).build();
-
-        Executable action = () -> UserDao.fromUserDto(userWithInvalidRole);
-        RuntimeException exception = assertThrows(RuntimeException.class, action);
-        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
-    }
+//    @ParameterizedTest
+//    @NullAndEmptySource
+//    void toUserDbThrowsExceptionWhenUserDbContainsInvalidRole(String invalidRoleName)
+//        throws InvalidEntryInternalException {
+//        RoleDto invalidRole = RoleDto.newBuilder().withRoleName(SOME_ROLENAME).build();
+//        invalidRole.setRoleName(invalidRoleName);
+//        List<RoleDto> invalidRoles = Collections.singletonList(invalidRole);
+//        UserDto userWithInvalidRole = UserDto.newBuilder().withUsername(SOME_USERNAME).withRoles(invalidRoles).build();
+//
+//        Executable action = () -> UserDao.fromUserDto(userWithInvalidRole);
+//        RuntimeException exception = assertThrows(RuntimeException.class, action);
+//        assertThat(exception.getCause(), is(instanceOf(InvalidEntryInternalException.class)));
+//    }
 
     @Test
     void roleValidationMethodLogsError()
         throws InvalidEntryInternalException {
         TestAppender appender = LogUtils.getTestingAppender(UserDao.class);
-        RoleDto invalidRole = RoleDto.newBuilder().withRoleName(SOME_ROLENAME).build();
+        RoleDto invalidRole = RoleDto.newBuilder().withRoleName(randomRoleName()).build();
         invalidRole.setRoleName(null);
 
         List<RoleDto> invalidRoles = Collections.singletonList(invalidRole);
@@ -273,14 +274,14 @@ class UserDaoTest {
     }
 
     private static List<RoleDb> createSampleRoles() {
-        return Stream.of("Role1", "Role2")
+        return Stream.of(randomRoleName(), randomRoleName())
             .map(attempt(UserDaoTest::newRole))
             .map(Try::get)
             .collect(Collectors.toList());
     }
 
-    private static RoleDb newRole(String str) throws InvalidEntryInternalException {
-        return RoleDb.newBuilder().withName(str).build();
+    private static RoleDb newRole(RoleName roleName) throws InvalidEntryInternalException {
+        return RoleDb.newBuilder().withName(roleName).build();
     }
 
     private UserDao randomUserDb() {
@@ -306,7 +307,7 @@ class UserDaoTest {
 
     private RoleDb randomRole() {
         Set<AccessRight> accessRight = Set.of(randomElement(AccessRight.values()));
-        return RoleDb.newBuilder().withName(randomString()).withAccessRights(accessRight).build();
+        return RoleDb.newBuilder().withName(randomRoleName()).withAccessRights(accessRight).build();
     }
 
     private UserDto convertToUserDbAndBack(UserDto userDto) throws InvalidEntryInternalException {

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleDto.java
@@ -1,6 +1,5 @@
 package no.unit.nva.useraccessservice.model;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonAlias;
@@ -12,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import no.unit.nva.identityservice.json.JsonConfig;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
@@ -31,7 +31,7 @@ public class RoleDto implements WithCopy<Builder>, Validable, Typed {
 
     @JsonAlias("name")
     @JsonProperty("rolename")
-    private String roleName;
+    private RoleName roleName;
     @JsonProperty("accessRights")
     private Set<AccessRight> accessRights;
 
@@ -64,12 +64,11 @@ public class RoleDto implements WithCopy<Builder>, Validable, Typed {
             .withRoleName(this.getRoleName());
     }
 
-    public String getRoleName() {
+    public RoleName getRoleName() {
         return roleName;
     }
 
-    public void setRoleName(String roleName) {
-
+    public void setRoleName(RoleName roleName) {
         this.roleName = roleName;
     }
 
@@ -84,7 +83,7 @@ public class RoleDto implements WithCopy<Builder>, Validable, Typed {
     @Override
     @JsonIgnore
     public boolean isValid() {
-        return !(isNull(this.getRoleName()) || this.getRoleName().isBlank());
+        return Optional.ofNullable(getRoleName()).map(RoleName::getValue).filter(value -> !value.isBlank()).isPresent();
     }
 
     @Override
@@ -132,7 +131,7 @@ public class RoleDto implements WithCopy<Builder>, Validable, Typed {
             roleDto = new RoleDto();
         }
 
-        public Builder withRoleName(String roleName) {
+        public Builder withRoleName(RoleName roleName) {
             roleDto.setRoleName(roleName);
             if (roleDto.isInvalid()) {
                 throw new InvalidEntryInternalException(MISSING_ROLE_NAME_ERROR);

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleDto.java
@@ -148,4 +148,10 @@ public class RoleDto implements WithCopy<Builder>, Validable, Typed {
             return roleDto;
         }
     }
+
+    @JacocoGenerated
+    @JsonIgnore
+    public boolean isNotDeprecated() {
+        return !getRoleName().isDeprecated();
+    }
 }

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
@@ -21,7 +21,9 @@ public enum RoleName {
     @Deprecated
     DEPRECATED_NVI_CURATOR("Nvi-curator"),
     @Deprecated
-    DEPRECATED_CURATOR("Curator");
+    DEPRECATED_CURATOR("Curator"),
+    @Deprecated
+    DEPRECATED_INTERNAL_IMPORT("Curator-Import-candidate");
 
     private final String value;
 
@@ -49,6 +51,8 @@ public enum RoleName {
     @JacocoGenerated
     @JsonIgnore
     public boolean isDeprecated() {
-        return this.equals(DEPRECATED_NVI_CURATOR) || this.equals(DEPRECATED_CURATOR);
+        return this.equals(DEPRECATED_NVI_CURATOR)
+               || this.equals(DEPRECATED_CURATOR)
+               || this.equals(DEPRECATED_INTERNAL_IMPORT);
     }
 }

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
@@ -1,0 +1,38 @@
+package no.unit.nva.useraccessservice.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+public enum RoleName {
+
+    PUBLISHING_CURATOR("Publishing-Curator"),
+    DOI_CURATOR("Doi-Curator"),
+    NVI_CURATOR("Nvi-Curator"),
+    SUPPORT_CURATOR("Support-Curator"),
+    INSTITUTION_ADMIN("Institution-admin"),
+    INTERNAL_IMPORTER("Internal-importer"),
+    THESIS_CURATOR("Curator-thesis"),
+    EMBARGO_THESIS_CURATOR("Curator-thesis-embargo"),
+    APPLICATION_ADMIN("App-admin"),
+    EDITOR("Editor"),
+    CREATOR("Creator");
+
+    private final String value;
+
+    RoleName(String value) {
+
+        this.value = value;
+    }
+
+    public static RoleName fromValue(String value) {
+        return Arrays.stream(RoleName.values())
+                   .filter(entry -> entry.getValue().equals(value))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
@@ -15,7 +15,9 @@ public enum RoleName {
     EMBARGO_THESIS_CURATOR("Curator-thesis-embargo"),
     APPLICATION_ADMIN("App-admin"),
     EDITOR("Editor"),
-    CREATOR("Creator");
+    CREATOR("Creator"),
+    @Deprecated
+    DEPRECATED_NVI_CURATOR("Nvi-curator");
 
     private final String value;
 

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
@@ -22,7 +22,6 @@ public enum RoleName {
     private final String value;
 
     RoleName(String value) {
-
         this.value = value;
     }
 
@@ -36,5 +35,10 @@ public enum RoleName {
     @JsonValue
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
     }
 }

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/RoleName.java
@@ -1,7 +1,9 @@
 package no.unit.nva.useraccessservice.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
+import nva.commons.core.JacocoGenerated;
 
 public enum RoleName {
 
@@ -17,7 +19,9 @@ public enum RoleName {
     EDITOR("Editor"),
     CREATOR("Creator"),
     @Deprecated
-    DEPRECATED_NVI_CURATOR("Nvi-curator");
+    DEPRECATED_NVI_CURATOR("Nvi-curator"),
+    @Deprecated
+    DEPRECATED_CURATOR("Curator");
 
     private final String value;
 
@@ -39,6 +43,12 @@ public enum RoleName {
 
     @Override
     public String toString() {
-        return getValue();
+        return value;
+    }
+
+    @JacocoGenerated
+    @JsonIgnore
+    public boolean isDeprecated() {
+        return this.equals(DEPRECATED_NVI_CURATOR) || this.equals(DEPRECATED_CURATOR);
     }
 }

--- a/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/UserDto.java
+++ b/user-access-public-model/src/main/java/no/unit/nva/useraccessservice/model/UserDto.java
@@ -179,6 +179,7 @@ public class UserDto implements WithCopy<Builder>, Typed {
     public Stream<String> generateRoleClaims() {
         return roles.stream()
                    .map(RoleDto::getRoleName)
+                   .map(RoleName::getValue)
                    .map(rolename -> rolename + AT + institution.toString());
     }
     

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/EntityUtils.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/EntityUtils.java
@@ -1,6 +1,7 @@
 package no.unit.nva.useraccessservice.model;
 
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
+import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
 import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValues;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -30,7 +31,7 @@ public final class EntityUtils {
      */
     public static UserDto createUserWithRolesAndInstitutionAndViewingScope()
         throws InvalidEntryInternalException {
-        var user = createUserWithRoleWithoutInstitution().copy()
+        var user = createUserWithRoleWithoutInstitution(randomRoleName()).copy()
             .withInstitution(SOME_INSTITUTION)
             .withViewingScope(randomViewingScope())
             .withCristinId(randomUri())
@@ -48,9 +49,9 @@ public final class EntityUtils {
      * @return {@link UserDto}
      * @throws InvalidEntryInternalException When the user is invalid. The user is supposed to be a valid user.
      */
-    public static UserDto createUserWithRoleWithoutInstitution()
+    public static UserDto createUserWithRoleWithoutInstitution(RoleName roleName)
         throws InvalidEntryInternalException {
-        RoleDto sampleRole = createRole(SOME_ROLENAME);
+        RoleDto sampleRole = createRole(roleName);
         return UserDto.newBuilder()
             .withUsername(SOME_USERNAME)
             .withGivenName(SOME_GIVEN_NAME)
@@ -62,14 +63,14 @@ public final class EntityUtils {
     /**
      * Creates a sample role.
      *
-     * @param someRole The sample role role name.
+     * @param roleName The sample role role name.
      * @return the sample role
      * @throws InvalidEntryInternalException when the generated role is invalid.
      */
-    public static RoleDto createRole(String someRole) throws InvalidEntryInternalException {
+    public static RoleDto createRole(RoleName roleName) throws InvalidEntryInternalException {
         return
             RoleDto.newBuilder()
-                .withRoleName(someRole)
+                .withRoleName(roleName)
                 .withAccessRights(SAMPLE_ACCESS_RIGHTS)
                 .build();
     }

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/RoleNameTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/RoleNameTest.java
@@ -1,0 +1,14 @@
+package no.unit.nva.useraccessservice.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class RoleNameTest {
+
+    @ParameterizedTest
+    @EnumSource(RoleName.class)
+    void shouldConvertStringToRoleNameEnum(RoleName roleName) {
+        assertEquals(roleName, RoleName.fromValue(roleName.getValue()));
+    }
+}

--- a/user-access-service/src/main/java/no/unit/nva/database/IdentityService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/IdentityService.java
@@ -55,7 +55,6 @@ public interface IdentityService {
     
     class Constants {
         
-        public static final String ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT = "Creator";
         public static final String USERS_AND_ROLES_TABLE =
             new Environment().readEnv("USERS_AND_ROLES_TABLE");
         

--- a/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
+++ b/user-access-service/src/main/java/no/unit/nva/database/RoleService.java
@@ -69,7 +69,7 @@ public class RoleService extends DatabaseSubService {
 
     private static NotFoundException handleRoleNotFound(RoleDto queryObject) {
         logger.debug(ROLE_NOT_FOUND_MESSAGE + queryObject.getRoleName());
-        return new NotFoundException(ROLE_NOT_FOUND_MESSAGE + queryObject.getRoleName());
+        return new NotFoundException(ROLE_NOT_FOUND_MESSAGE + queryObject.getRoleName().getValue());
     }
 
     private Optional<RoleDto> getRoleAsOptional(RoleDto queryObject) {

--- a/user-access-service/src/test/java/no/unit/nva/database/EntityUtils.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/EntityUtils.java
@@ -1,10 +1,13 @@
 package no.unit.nva.database;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import javax.management.relation.Role;
 import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import nva.commons.apigateway.AccessRight;
 
@@ -12,11 +15,11 @@ public final class EntityUtils {
 
     public static final String SOME_ROLENAME = "SomeRole";
 
-    public static RoleDto createRole(String roleName) throws InvalidEntryInternalException {
+    public static RoleDto createRole(RoleName roleName) throws InvalidEntryInternalException {
         return createRole(roleName, AccessRight.MANAGE_DOI);
     }
 
-    public static RoleDto createRole(String roleName, AccessRight... accessRights) {
+    public static RoleDto createRole(RoleName roleName, AccessRight... accessRights) {
         var accessRightSet = Arrays.stream(accessRights).collect(Collectors.toSet());
 
         return RoleDto.newBuilder()
@@ -27,5 +30,9 @@ public final class EntityUtils {
 
     public static UserDto createUser() {
         return UserDto.newBuilder().withUsername(randomString()).build();
+    }
+
+    public static RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
     }
 }

--- a/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceImplTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceImplTest.java
@@ -44,7 +44,7 @@ public class IdentityServiceImplTest extends LocalIdentityService {
         throws InvalidEntryInternalException {
 
         IdentityService serviceThrowingException = mockServiceThrowsExceptionWhenLoadingRole();
-        RoleDto sampleRole = EntityUtils.createRole(EntityUtils.SOME_ROLENAME);
+        RoleDto sampleRole = EntityUtils.createRole(EntityUtils.randomRoleName());
         Executable action = () -> serviceThrowingException.getRole(sampleRole);
         RuntimeException exception = assertThrows(RuntimeException.class, action);
 
@@ -54,7 +54,7 @@ public class IdentityServiceImplTest extends LocalIdentityService {
     @Test
     public void getRoleLogsWarningWhenNotFoundExceptionIsThrown() throws InvalidEntryInternalException {
         TestAppender testAppender = LogUtils.getTestingAppender(RoleService.class);
-        RoleDto nonExistingRole = EntityUtils.createRole(EntityUtils.SOME_ROLENAME);
+        RoleDto nonExistingRole = EntityUtils.createRole(EntityUtils.randomRoleName());
         attempt(() -> databaseService.getRole(nonExistingRole));
         assertThat(testAppender.getMessages(),
                    StringContains.containsString(ROLE_NOT_FOUND_MESSAGE));
@@ -62,7 +62,7 @@ public class IdentityServiceImplTest extends LocalIdentityService {
 
     @Test
     void shouldSucceedUpdatingAnExistingRole() throws InvalidInputException, ConflictException, NotFoundException {
-        var existingRole = EntityUtils.createRole(randomString(), MANAGE_DOI);
+        var existingRole = EntityUtils.createRole(EntityUtils.randomRoleName(), MANAGE_DOI);
         databaseService.addRole(existingRole);
 
         var updatedAccessRights = Set.of(MANAGE_DOI, MANAGE_PUBLISHING_REQUESTS);
@@ -77,7 +77,7 @@ public class IdentityServiceImplTest extends LocalIdentityService {
     @Test
     void updateRoleLogsWarningWhenNotFoundExceptionIsThrown() throws InvalidEntryInternalException {
         TestAppender testAppender = LogUtils.getTestingAppender(RoleService.class);
-        RoleDto role = EntityUtils.createRole(EntityUtils.SOME_ROLENAME);
+        RoleDto role = EntityUtils.createRole(EntityUtils.randomRoleName());
         assertThrows(NotFoundException.class, () -> databaseService.updateRole(role));
         assertThat(testAppender.getMessages(),
                    StringContains.containsString(ROLE_NOT_FOUND_MESSAGE));
@@ -87,7 +87,7 @@ public class IdentityServiceImplTest extends LocalIdentityService {
     void shouldListAllUsersWhenDatabseAlsoIncludesRoles() throws ConflictException, InvalidInputException {
         databaseService.addUser(EntityUtils.createUser());
         databaseService.addUser(EntityUtils.createUser());
-        databaseService.addRole(EntityUtils.createRole(randomString()));
+        databaseService.addRole(EntityUtils.createRole(EntityUtils.randomRoleName()));
 
         var users = databaseService.listAllUsers();
         assertThat(users, hasSize(2));

--- a/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceTest.java
@@ -56,7 +56,6 @@ import nva.commons.logutils.TestAppender;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;

--- a/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceTest.java
+++ b/user-access-service/src/test/java/no/unit/nva/database/IdentityServiceTest.java
@@ -3,8 +3,8 @@ package no.unit.nva.database;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
-import static no.unit.nva.database.EntityUtils.SOME_ROLENAME;
 import static no.unit.nva.database.EntityUtils.createRole;
+import static no.unit.nva.database.EntityUtils.randomRoleName;
 import static no.unit.nva.database.RoleService.ROLE_ALREADY_EXISTS_ERROR_MESSAGE;
 import static no.unit.nva.database.RoleService.ROLE_NOT_FOUND_MESSAGE;
 import static no.unit.nva.database.UserService.USER_ALREADY_EXISTS_ERROR_MESSAGE;
@@ -43,6 +43,7 @@ import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.ClientDto;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.model.ViewingScope;
 import nva.commons.apigateway.AccessRight;
@@ -74,7 +75,6 @@ class IdentityServiceTest extends LocalIdentityService {
     private static final String SOME_FAMILY_NAME = "familyName";
 
     private static final URI SOME_INSTITUTION = randomCristinOrgId();
-    private static final String SOME_OTHER_ROLE = "SOME_OTHER_ROLE";
     private static final URI SOME_OTHER_INSTITUTION = randomCristinOrgId();
     private IdentityService identityService;
     private DynamoDbTable<RoleDb> rolesTable;
@@ -91,7 +91,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @DisplayName("getRole() throws NotFoundException when the role-name does not exist in the database")
     @Test
     void databaseServiceThrowsNotFoundExceptionWhenRoleNameDoesNotExist() throws InvalidEntryInternalException {
-        RoleDto queryObject = createRole(SOME_ROLENAME);
+        RoleDto queryObject = createRole(EntityUtils.randomRoleName());
         Executable action = () -> identityService.getRole(queryObject);
 
         NotFoundException exception = assertThrows(NotFoundException.class, action);
@@ -102,7 +102,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void addRoleInsertsValidItemInDatabase()
         throws InvalidEntryInternalException, NotFoundException, InvalidInputException, ConflictException {
-        RoleDto insertedUser = createSampleRoleAndAddToDb(SOME_ROLENAME);
+        RoleDto insertedUser = createSampleRoleAndAddToDb(randomRoleName());
         RoleDto savedUser = identityService.getRole(insertedUser);
 
         assertThat(insertedUser, doesNotHaveEmptyValues());
@@ -123,7 +123,7 @@ class IdentityServiceTest extends LocalIdentityService {
     void addRoleThrowsConflictExceptionWhenTryingToSaveAlreadyExistingUser()
         throws InvalidEntryInternalException, InvalidInputException, ConflictException {
 
-        String conflictingRoleName = SOME_ROLENAME;
+        var conflictingRoleName = EntityUtils.randomRoleName();
         createSampleRoleAndAddToDb(conflictingRoleName);
 
         RoleDto conflictingRole = createRole(conflictingRoleName);
@@ -137,7 +137,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void databaseServiceReturnsNonEmptyUserWhenUsernameExistsInDatabase()
         throws InvalidEntryInternalException, ConflictException, NotFoundException, InvalidInputException {
-        UserDto insertedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        UserDto insertedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         UserDto savedUser = identityService.getUser(insertedUser);
 
         assertThat(insertedUser, doesNotHaveEmptyValues());
@@ -171,10 +171,10 @@ class IdentityServiceTest extends LocalIdentityService {
         throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException {
 
         String conflictingUsername = SOME_USERNAME;
-        createSampleUserAndAddUserToDb(conflictingUsername, SOME_INSTITUTION, SOME_ROLENAME);
+        createSampleUserAndAddUserToDb(conflictingUsername, SOME_INSTITUTION, randomRoleName());
 
         UserDto conflictingUser = createUserWithRole(conflictingUsername,
-                                                     SOME_OTHER_INSTITUTION, createRole(SOME_OTHER_ROLE));
+                                                     SOME_OTHER_INSTITUTION, createRole(randomRoleName()));
 
         Executable action = () -> identityService.addUser(conflictingUser);
         ConflictException exception = assertThrows(ConflictException.class, action);
@@ -184,7 +184,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void addUserAddsCurrentlySavedVersionOfRoleInNewUser()
         throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException {
-        RoleDto existingRole = createSampleRoleAndAddToDb(SOME_ROLENAME);
+        RoleDto existingRole = createSampleRoleAndAddToDb(randomRoleName());
         assertThat(existingRole, doesNotHaveEmptyValues());
 
         UserDto userWithoutRoleDetails = createUserWithRoleReference(existingRole);
@@ -199,7 +199,7 @@ class IdentityServiceTest extends LocalIdentityService {
     void updateUserUpdatesExistingUserWithInputUserWhenInputUserIsValid()
         throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException,
                BadRequestException {
-        UserDto existingUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        UserDto existingUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         UserDto expectedUser = cloneAndAddNewRoleAndViewingScope(existingUser);
 
         identityService.updateUser(expectedUser);
@@ -212,7 +212,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void updateUserThrowsNotFoundExceptionWhenTheInputUsernameDoesNotExist()
         throws InvalidEntryInternalException {
-        UserDto userUpdate = createSampleUser(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        UserDto userUpdate = createSampleUser(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         Executable action = () -> identityService.updateUser(userUpdate);
         NotFoundException exception = assertThrows(NotFoundException.class, action);
         assertThat(exception.getMessage(), containsString(USER_NOT_FOUND_MESSAGE));
@@ -223,7 +223,7 @@ class IdentityServiceTest extends LocalIdentityService {
     void updateUserThrowsExceptionWhenTheInputIsInvalid()
         throws ConflictException, InvalidEntryInternalException,
                NotFoundException, InvalidInputException {
-        createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         UserDto invalidUser = new UserDto();
         Executable action = () -> identityService.updateUser(invalidUser);
         assertThrows(RuntimeException.class, action);
@@ -233,8 +233,8 @@ class IdentityServiceTest extends LocalIdentityService {
     void listUsersByInstitutionReturnsAllUsersForSpecifiedInstitution()
         throws ConflictException, InvalidEntryInternalException,
                NotFoundException, InvalidInputException {
-        UserDto someUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
-        UserDto someOtherUser = createSampleUserAndAddUserToDb(SOME_OTHER_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        UserDto someUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
+        UserDto someOtherUser = createSampleUserAndAddUserToDb(SOME_OTHER_USERNAME, SOME_INSTITUTION, randomRoleName());
         List<UserDto> queryResult = identityService.listUsers(SOME_INSTITUTION);
         assertThat(queryResult, containsInAnyOrder(someUser, someOtherUser));
     }
@@ -242,7 +242,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void listUsersByInstitutionReturnsEmptyListWhenThereAreNoUsersForSpecifiedInstitution()
         throws ConflictException, InvalidEntryInternalException, NotFoundException, InvalidInputException {
-        createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         List<UserDto> queryResult = identityService.listUsers(SOME_OTHER_INSTITUTION);
         assertThat(queryResult, is(empty()));
     }
@@ -253,7 +253,7 @@ class IdentityServiceTest extends LocalIdentityService {
 
         RoleDb roleWithAccessRights = RoleDb.newBuilder()
                                           .withAccessRights(accessRights)
-                                          .withName(SOME_ROLENAME)
+                                          .withName(randomRoleName())
                                           .build();
 
         rolesTable.putItem(roleWithAccessRights);
@@ -266,7 +266,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void databaseServiceReturnsNonEmptyRoleWhenRoleNameExistsInDatabase()
         throws InvalidEntryInternalException, NotFoundException, InvalidInputException, ConflictException {
-        RoleDto insertedRole = createSampleRoleAndAddToDb(SOME_ROLENAME);
+        RoleDto insertedRole = createSampleRoleAndAddToDb(randomRoleName());
         RoleDto savedRole = identityService.getRole(insertedRole);
 
         assertThat(insertedRole, doesNotHaveEmptyValues());
@@ -276,7 +276,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void addUserInsertsValidItemInDatabase()
         throws InvalidEntryInternalException, ConflictException, NotFoundException, InvalidInputException {
-        UserDto insertedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME);
+        UserDto insertedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, SOME_INSTITUTION, randomRoleName());
         assertThat(insertedUser, doesNotHaveEmptyValues());
         UserDto savedUser = identityService.getUser(insertedUser);
 
@@ -287,7 +287,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void addUserSavesAUserWithoutInstitution() throws InvalidEntryInternalException, ConflictException,
                                                       NotFoundException, InvalidInputException {
-        UserDto expectedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, null, SOME_ROLENAME);
+        UserDto expectedUser = createSampleUserAndAddUserToDb(SOME_USERNAME, null, randomRoleName());
         UserDto actualUser = identityService.getUser(expectedUser);
 
         assertThat(actualUser, is(equalTo(expectedUser)));
@@ -297,7 +297,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void addUserDoesNotAddNonExistingRolesInCreatedUser() throws ConflictException, NotFoundException {
         UserDto userWithNonExistingRole = createUserWithRole(SOME_USERNAME, SOME_INSTITUTION,
-                                                             createRole(SOME_ROLENAME));
+                                                             createRole(randomRoleName()));
         identityService.addUser(userWithNonExistingRole);
 
         UserDto actualUser = identityService.getUser(userWithNonExistingRole);
@@ -310,7 +310,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void updateUserUpdatesAssignsCorrectVersionOfRoleInUser()
         throws ConflictException, NotFoundException, InvalidInputException {
-        RoleDto existingRole = createRole(SOME_ROLENAME);
+        RoleDto existingRole = createRole(randomRoleName());
         identityService.addRole(existingRole);
 
         UserDto existingUser = createUserWithRole(SOME_USERNAME, SOME_INSTITUTION, existingRole);
@@ -363,7 +363,7 @@ class IdentityServiceTest extends LocalIdentityService {
     @Test
     void getRoleLogsWarningWhenNotFoundExceptionIsThrown() throws InvalidEntryInternalException {
         TestAppender testAppender = LogUtils.getTestingAppender(RoleService.class);
-        RoleDto nonExistingRole = EntityUtils.createRole(EntityUtils.SOME_ROLENAME);
+        RoleDto nonExistingRole = EntityUtils.createRole(EntityUtils.randomRoleName());
         attempt(() -> databaseService.getRole(nonExistingRole));
         assertThat(testAppender.getMessages(),
                    StringContains.containsString(ROLE_NOT_FOUND_MESSAGE));
@@ -449,7 +449,7 @@ class IdentityServiceTest extends LocalIdentityService {
 
     private static RoleDb randomRole() {
         return RoleDb.newBuilder()
-                   .withName(randomString())
+                   .withName(randomRoleName())
                    .withAccessRights(Set.of(randomElement(AccessRight.values())))
                    .build();
     }
@@ -482,7 +482,7 @@ class IdentityServiceTest extends LocalIdentityService {
     private void createSampleUsers(int numberOfUsers)
         throws ConflictException, NotFoundException, InvalidInputException {
         for (int counter = 0; counter < numberOfUsers; counter++) {
-            createSampleUserAndAddUserToDb(randomString(), randomUri(), randomString());
+            createSampleUserAndAddUserToDb(randomString(), randomUri(), randomRoleName());
         }
     }
 
@@ -511,7 +511,7 @@ class IdentityServiceTest extends LocalIdentityService {
     private UserDto createUserWithRoleReference(RoleDto existingRole)
         throws InvalidEntryInternalException {
         RoleDto roleWithoutDetails = RoleDto.newBuilder().withRoleName(existingRole.getRoleName()).build();
-        return createSampleUser(SOME_USERNAME, SOME_INSTITUTION, SOME_ROLENAME)
+        return createSampleUser(SOME_USERNAME, SOME_INSTITUTION, randomRoleName())
                    .copy()
                    .withRoles(Collections.singletonList(roleWithoutDetails))
                    .build();
@@ -526,7 +526,8 @@ class IdentityServiceTest extends LocalIdentityService {
 
     private UserDto userUpdateWithRoleMissingAccessRights(UserDto existingUser)
         throws InvalidEntryInternalException {
-        RoleDto roleWithOnlyRolename = RoleDto.newBuilder().withRoleName(SOME_ROLENAME).build();
+        RoleDto roleWithOnlyRolename =
+            RoleDto.newBuilder().withRoleName(existingUser.getRoles().stream().findFirst().orElseThrow().getRoleName()).build();
         return existingUser.copy()
                    .withGivenName(SOME_GIVEN_NAME)
                    .withRoles(Collections.singletonList(roleWithOnlyRolename))
@@ -543,14 +544,14 @@ class IdentityServiceTest extends LocalIdentityService {
     }
 
     private RoleDto createIllegalRole() throws InvalidEntryInternalException {
-        RoleDto illegalRole = createRole(SOME_ROLENAME);
+        RoleDto illegalRole = createRole(randomRoleName());
         illegalRole.setRoleName(null);
         return illegalRole;
     }
 
     private UserDto cloneAndAddNewRoleAndViewingScope(UserDto existingUser)
         throws InvalidEntryInternalException, InvalidInputException, ConflictException, BadRequestException {
-        var someOtherRole = createRole(SOME_OTHER_ROLE);
+        var someOtherRole = createRole(randomRoleName());
         var viewingScope = ViewingScope.create(Set.of(randomCristinOrgId()), Set.of(randomCristinOrgId()));
 
         identityService.addRole(someOtherRole);
@@ -559,7 +560,7 @@ class IdentityServiceTest extends LocalIdentityService {
                    .build();
     }
 
-    private UserDto createSampleUserAndAddUserToDb(String username, URI institution, String roleName)
+    private UserDto createSampleUserAndAddUserToDb(String username, URI institution, RoleName roleName)
         throws InvalidEntryInternalException, ConflictException,
                NotFoundException, InvalidInputException {
         var userDto = createSampleUser(username, institution, roleName);
@@ -579,7 +580,7 @@ class IdentityServiceTest extends LocalIdentityService {
         }
     }
 
-    private UserDto createSampleUser(String username, URI institution, String roleName)
+    private UserDto createSampleUser(String username, URI institution, RoleName roleName)
         throws InvalidEntryInternalException {
         return UserDto.newBuilder()
                    .withRoles(createRoleList(roleName))
@@ -595,7 +596,7 @@ class IdentityServiceTest extends LocalIdentityService {
                    .build();
     }
 
-    private RoleDto createSampleRoleAndAddToDb(String roleName)
+    private RoleDto createSampleRoleAndAddToDb(RoleName roleName)
         throws InvalidEntryInternalException, InvalidInputException, ConflictException {
         RoleDto roleDto = createRole(roleName);
         identityService.addRole(roleDto);
@@ -603,7 +604,7 @@ class IdentityServiceTest extends LocalIdentityService {
         return roleDto;
     }
 
-    private List<RoleDto> createRoleList(String rolename) throws InvalidEntryInternalException {
+    private List<RoleDto> createRoleList(RoleName rolename) throws InvalidEntryInternalException {
         if (nonNull(rolename)) {
             RoleDto roleDto = createRole(rolename);
             return Collections.singletonList(roleDto);

--- a/user-access-testing/src/main/java/no/unit/nva/RandomUserDataGenerator.java
+++ b/user-access-testing/src/main/java/no/unit/nva/RandomUserDataGenerator.java
@@ -1,11 +1,15 @@
 package no.unit.nva;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.useraccessservice.constants.ServiceConstants.API_DOMAIN;
 import static no.unit.nva.useraccessservice.constants.ServiceConstants.CRISTIN_PATH;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Set;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.ViewingScope;
 import nva.commons.core.paths.UriWrapper;
 
@@ -25,5 +29,15 @@ public final class RandomUserDataGenerator {
     public static ViewingScope randomViewingScope() {
         return attempt(() -> ViewingScope.create(Set.of(randomCristinOrgId()), Set.of(randomCristinOrgId())))
                    .orElseThrow();
+    }
+
+    public static RoleName randomRoleName() {
+        return RoleName.values()[randomInteger(RoleName.values().length)];
+    }
+
+    public static RoleName randomRoleNameButNot(RoleName roleName) {
+        var values = new ArrayList<>(Arrays.asList(RoleName.values()));
+        values.remove(roleName);
+        return values.get(randomInteger(values.size()));
     }
 }

--- a/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/AuthenticationScenarios.java
+++ b/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/AuthenticationScenarios.java
@@ -1,6 +1,5 @@
 package no.unit.nva.useraccessservice.userceation.testing.cristin;
 
-import static no.unit.nva.database.IdentityService.Constants.ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
@@ -19,6 +18,7 @@ import no.unit.nva.customer.service.CustomerService;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.useraccessservice.exceptions.InvalidInputException;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinAffiliation;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinPerson;
@@ -161,7 +161,7 @@ public class AuthenticationScenarios {
 
     private void addCreatorRoleToIdentityService(IdentityService identityService)
         throws InvalidInputException, ConflictException {
-        var creatorRole = RoleDto.newBuilder().withRoleName(ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT)
+        var creatorRole = RoleDto.newBuilder().withRoleName(RoleName.CREATOR)
                               .build();
         identityService.addRole(creatorRole);
     }

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/UserEntriesCreatorForPerson.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/UserEntriesCreatorForPerson.java
@@ -1,6 +1,5 @@
 package no.unit.nva.useraccessservice.usercreation;
 
-import static no.unit.nva.database.IdentityService.Constants.ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.util.Collections;
@@ -9,6 +8,7 @@ import java.util.stream.Collectors;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.database.IdentityService;
 import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
 import no.unit.nva.useraccessservice.model.UserDto;
 import no.unit.nva.useraccessservice.usercreation.person.Person;
 import nva.commons.apigateway.exceptions.ConflictException;
@@ -17,7 +17,7 @@ import nva.commons.core.paths.UriWrapper;
 
 public class UserEntriesCreatorForPerson {
     public static final RoleDto ROLE_FOR_PEOPLE_WITH_ACTIVE_AFFILIATION =
-        RoleDto.newBuilder().withRoleName(ROLE_ACQUIRED_BY_ALL_PEOPLE_WITH_ACTIVE_EMPLOYMENT).build();
+        RoleDto.newBuilder().withRoleName(RoleName.CREATOR).build();
     private static final String AT = "@";
     private final IdentityService identityService;
 


### PR DESCRIPTION
We had a case where "old" role has still been attached to user in NVA. It caused that user had access rights we did not know about, cause role and all belongings access rights have not been removed/ updated when we updated user roles via api. 

To fix this case and all future cases we decided to make RoleName to enum, so all unknown values will fail on serialization. 

- Since roleName has been string before, had to update a lot of tests. 
- RoleName is still stored as String in database and all enum values have the same role names as before.