### PR TITLE
adding isActive property to CustomerPreference

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
@@ -1,20 +1,18 @@
 package no.unit.nva.customer.model;
 
-import nva.commons.core.JacocoGenerated;
-
+import static java.util.Objects.nonNull;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
-
-import static java.util.Objects.nonNull;
+import nva.commons.core.JacocoGenerated;
 
 public class CustomerReference {
 
     private URI id;
     private String displayName;
     private Instant createdDate;
-
+    private boolean active;
     private String doiPrefix;
 
     public static CustomerReference fromCustomerDto(CustomerDto customerDto) {
@@ -23,14 +21,16 @@ public class CustomerReference {
         customerReference.setId(customerDto.getId());
         customerReference.setCreatedDate(customerDto.getCreatedDate());
         customerReference.setDoiPrefix(extractDoiPrefix(customerDto));
+        customerReference.setActive(customerReference.isActive());
         return customerReference;
     }
 
-    private static String extractDoiPrefix(CustomerDto customerDto) {
-        return Optional
-                .ofNullable(customerDto.getDoiAgent())
-                .map(CustomerDto.DoiAgentDto::getPrefix)
-                .orElse(null);
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 
     public URI getId() {
@@ -70,10 +70,7 @@ public class CustomerReference {
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(getId(),
-                getDisplayName(),
-                getDoiPrefix(),
-                getCreatedDate());
+        return Objects.hash(getId(), getDisplayName(), getDoiPrefix(), getCreatedDate());
     }
 
     @JacocoGenerated
@@ -85,9 +82,12 @@ public class CustomerReference {
         if (!(o instanceof CustomerReference that)) {
             return false;
         }
-        return Objects.equals(getId(), that.getId())
-                && Objects.equals(getDisplayName(), that.getDisplayName())
-                && Objects.equals(getDoiPrefix(), that.getDoiPrefix())
-                && Objects.equals(getCreatedDate(), that.getCreatedDate());
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getDisplayName(), that.getDisplayName()) &&
+               Objects.equals(getDoiPrefix(), that.getDoiPrefix()) &&
+               Objects.equals(getCreatedDate(), that.getCreatedDate());
+    }
+
+    private static String extractDoiPrefix(CustomerDto customerDto) {
+        return Optional.ofNullable(customerDto.getDoiAgent()).map(CustomerDto.DoiAgentDto::getPrefix).orElse(null);
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
-import nva.commons.core.JacocoGenerated;
 
 public class CustomerReference {
 
@@ -23,6 +22,22 @@ public class CustomerReference {
         customerReference.setDoiPrefix(extractDoiPrefix(customerDto));
         customerReference.setActive(customerReference.isActive());
         return customerReference;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getDisplayName(), getCreatedDate(), isActive(), getDoiPrefix());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof CustomerReference that)) {
+            return false;
+        }
+        return isActive() == that.isActive() && Objects.equals(getId(), that.getId()) &&
+               Objects.equals(getDisplayName(), that.getDisplayName()) &&
+               Objects.equals(getCreatedDate(), that.getCreatedDate()) &&
+               Objects.equals(getDoiPrefix(), that.getDoiPrefix());
     }
 
     public boolean isActive() {
@@ -65,26 +80,6 @@ public class CustomerReference {
     @SuppressWarnings({"PMD.NullAssignment"})
     public void setCreatedDate(String createdDate) {
         this.createdDate = nonNull(createdDate) ? Instant.parse(createdDate) : null;
-    }
-
-    @JacocoGenerated
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId(), getDisplayName(), getDoiPrefix(), getCreatedDate());
-    }
-
-    @JacocoGenerated
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CustomerReference that)) {
-            return false;
-        }
-        return Objects.equals(getId(), that.getId()) && Objects.equals(getDisplayName(), that.getDisplayName()) &&
-               Objects.equals(getDoiPrefix(), that.getDoiPrefix()) &&
-               Objects.equals(getCreatedDate(), that.getCreatedDate());
     }
 
     private static String extractDoiPrefix(CustomerDto customerDto) {


### PR DESCRIPTION
When listing Customers, frontend needs to know if Customer is active or not. Adding isActive property to CustomerPreference which is the short representation of customer served to frontend when listing customers.

I do not feel this is something we want to test? If I add a test for it, I feel we want a test for other params as well, any opinions?

