### PR TITLE
[np-48788] feat: Include CristinId in GetAll endpoint

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerReference.java
@@ -10,6 +10,7 @@ import nva.commons.core.JacocoGenerated;
 public class CustomerReference {
 
     private URI id;
+    private URI cristinId;
     private String displayName;
     private Instant createdDate;
     private boolean active;
@@ -20,6 +21,7 @@ public class CustomerReference {
         var customerReference = new CustomerReference();
         customerReference.setDisplayName(customerDto.getDisplayName());
         customerReference.setId(customerDto.getId());
+        customerReference.setCristinId(customerDto.getCristinId());
         customerReference.setCreatedDate(customerDto.getCreatedDate());
         customerReference.setDoiPrefix(extractDoiPrefix(customerDto));
         customerReference.setActive(customerDto.isActive());
@@ -30,7 +32,7 @@ public class CustomerReference {
     @JacocoGenerated
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getDisplayName(), getCreatedDate(), isActive(), getDoiPrefix());
+        return Objects.hash(getId(), getCristinId(), getDisplayName(), getCreatedDate(), isActive(), getDoiPrefix());
     }
 
     @JacocoGenerated
@@ -39,10 +41,12 @@ public class CustomerReference {
         if (!(o instanceof CustomerReference that)) {
             return false;
         }
-        return isActive() == that.isActive() && Objects.equals(getId(), that.getId()) &&
-               Objects.equals(getDisplayName(), that.getDisplayName()) &&
-               Objects.equals(getCreatedDate(), that.getCreatedDate()) &&
-               Objects.equals(getDoiPrefix(), that.getDoiPrefix());
+        return isActive() == that.isActive()
+               && Objects.equals(getId(), that.getId())
+               && Objects.equals(getCristinId(), that.getCristinId())
+               && Objects.equals(getDisplayName(), that.getDisplayName())
+               && Objects.equals(getCreatedDate(), that.getCreatedDate())
+               && Objects.equals(getDoiPrefix(), that.getDoiPrefix());
     }
 
     public boolean isActive() {
@@ -59,6 +63,14 @@ public class CustomerReference {
 
     public void setId(URI id) {
         this.id = id;
+    }
+
+    public URI getCristinId() {
+        return cristinId;
+    }
+
+    public void setCristinId(URI cristinId) {
+        this.cristinId = cristinId;
     }
 
     public String getDisplayName() {

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerReferenceTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerReferenceTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.customer.model;
 
+import static no.unit.nva.customer.testing.CustomerDataGenerator.createSampleCustomerDto;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,15 @@ class CustomerReferenceTest {
         var expectedCustomerReference = constructExpectedCustomerReference(customerDto);
 
         assertEquals(expectedCustomerReference, CustomerReference.fromCustomerDto(customerDto));
+    }
+
+    @Test
+    void shouldIncludeNviInformationInCustomerReference() {
+        var customerDto = createSampleCustomerDto().copy().withNviInstitution(true).build();
+        var customerReference = CustomerReference.fromCustomerDto(customerDto);
+
+        assertEquals(customerReference.getCristinId(), customerDto.getCristinId());
+        assertEquals(customerReference.isNviInstitution(), customerDto.isNviInstitution());
     }
 
     private static CustomerReference constructExpectedCustomerReference(CustomerDto customerDto) {

--- a/docs/customer-swagger.yaml
+++ b/docs/customer-swagger.yaml
@@ -882,6 +882,9 @@ components:
         id:
           type: string
           format: uri
+        cristinId:
+          type: string
+          format: uri
         displayName:
           type: string
         createdDate:
@@ -889,6 +892,8 @@ components:
           format: date-time
         doiPrefix:
           type: string
+        nviInstitution:
+          type: boolean
     DoiAgent:
       type: object
       properties:
@@ -1084,9 +1089,12 @@ components:
         type: CustomerList
         customers:
           - id: 'https://api.test.nva.unit.no/customers/3fa85f64-5717-4562-b3fc-2c963f66afa6'
+            cristinId: 'https://api.test.nva.aws.unit.no/cristin/organization/1.2.3.4'
             createdDate: '2021-05-07T14:29:04.144Z'
+            active: true
             displayName: 'Universitet for Reindrift'
             doiPrefix: "1000.10"
+            nviInstitution: false
     DoiAgentExample:
       value:
         id: 'https://example.com/example/#/doiagent'

--- a/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/UserDaoTest.java
+++ b/user-access-internal-model/src/test/java/no/unit/nva/useraccessservice/dao/UserDaoTest.java
@@ -1,33 +1,5 @@
 package no.unit.nva.useraccessservice.dao;
 
-import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
-import no.unit.nva.useraccessservice.model.RoleDto;
-import no.unit.nva.useraccessservice.model.RoleName;
-import no.unit.nva.useraccessservice.model.UserDto;
-import nva.commons.apigateway.AccessRight;
-import nva.commons.apigateway.exceptions.BadRequestException;
-import nva.commons.core.attempt.Try;
-import nva.commons.logutils.LogUtils;
-import nva.commons.logutils.TestAppender;
-import org.hamcrest.core.StringContains;
-import org.javers.core.Javers;
-import org.javers.core.JaversBuilder;
-import org.javers.core.diff.Diff;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import java.net.URI;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
 import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.RandomUserDataGenerator.randomViewingScope;
@@ -49,6 +21,34 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
+import no.unit.nva.useraccessservice.model.RoleDto;
+import no.unit.nva.useraccessservice.model.RoleName;
+import no.unit.nva.useraccessservice.model.UserDto;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.attempt.Try;
+import nva.commons.logutils.LogUtils;
+import nva.commons.logutils.TestAppender;
+import org.hamcrest.core.StringContains;
+import org.javers.core.Javers;
+import org.javers.core.JaversBuilder;
+import org.javers.core.diff.Diff;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class UserDaoTest {
 
@@ -141,8 +141,8 @@ class UserDaoTest {
         assertThat(sampleUser.getPrimaryKeyHashKey(), is(equalTo(expectedHashKey)));
     }
 
-    @ParameterizedTest(name = "builder should throw exception when username is:\"{0}\"")
-    @NullAndEmptySource
+    @ParameterizedTest
+    @MethodSource("invalidNameProvider")
     void builderShouldThrowExceptionWhenUsernameIsNotValid(String invalidUsername) {
         Executable action = () -> UserDao.newBuilder()
             .withUsername(invalidUsername)
@@ -156,12 +156,19 @@ class UserDaoTest {
         assertThat(exception.getMessage(), containsString(UserDao.INVALID_USER_EMPTY_USERNAME));
     }
 
-    @ParameterizedTest(name = "setUsername should throw exception when input is:\"{0}\"")
-    @NullAndEmptySource
-    @ValueSource(strings = {" ", "\t", "", "\n"})
+    @ParameterizedTest
+    @MethodSource("invalidNameProvider")
     void setUsernameThrowsExceptionWhenUsernameIsNotValid(String invalidUsername) {
         UserDao userDao = new UserDao();
         assertThrows(InvalidEntryInternalException.class, () -> userDao.setUsername(invalidUsername));
+    }
+
+    private static Stream<Arguments> invalidNameProvider() {
+        return Stream.of(argumentSet("null string", (String) null),
+                         argumentSet("Empty string", ""),
+                         argumentSet("Space character", " "),
+                         argumentSet("Tab character", "\t"),
+                         argumentSet("Newline character", "\n"));
     }
 
 //    @ParameterizedTest(name = "fromUserDb throws Exception user contains invalidRole. Rolename:\"{0}\"")

--- a/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/UserDtoTest.java
+++ b/user-access-public-model/src/test/java/no/unit/nva/useraccessservice/model/UserDtoTest.java
@@ -1,29 +1,5 @@
 package no.unit.nva.useraccessservice.model;
 
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
-import no.unit.nva.commons.json.JsonUtils;
-import no.unit.nva.identityservice.json.JsonConfig;
-import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
-import nva.commons.apigateway.AccessRight;
-import nva.commons.apigateway.exceptions.BadRequestException;
-import nva.commons.core.attempt.Try;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static no.unit.nva.RandomUserDataGenerator.randomCristinOrgId;
 import static no.unit.nva.RandomUserDataGenerator.randomRoleName;
 import static no.unit.nva.RandomUserDataGenerator.randomRoleNameButNot;
@@ -49,6 +25,30 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.identityservice.json.JsonConfig;
+import no.unit.nva.useraccessservice.exceptions.InvalidEntryInternalException;
+import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.core.attempt.Try;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class UserDtoTest extends DtoTest {
 
@@ -186,12 +186,19 @@ class UserDtoTest extends DtoTest {
         assertThat(user.getInstitution(), is(equalTo(SOME_INSTITUTION)));
     }
 
-    @ParameterizedTest(name = "build throws exception when username is:\"{0}\"")
-    @NullAndEmptySource
-    @ValueSource(strings = {" ", "\t", "\n"})
+    @ParameterizedTest
+    @MethodSource("invalidNameProvider")
     void buildThrowsExceptionWhenUsernameIsNullOrEmpty(String username) {
         Executable action = () -> UserDto.newBuilder().withUsername(username).build();
         assertThrows(RuntimeException.class, action);
+    }
+
+    private static Stream<Arguments> invalidNameProvider() {
+        return Stream.of(argumentSet("null string", (String) null),
+                         argumentSet("Empty string", ""),
+                         argumentSet("Space character", " "),
+                         argumentSet("Tab character", "\t"),
+                         argumentSet("Newline character", "\n"));
     }
 
     @Test


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48788

Adds the Cristin ID of a customer organization to the "get all customers" endpoint (`GET /customer/`) to support data ingestion in `nva-nvi`. This process currently calls the `GET /customer/cristinId/{cristinId}` endpoint for each contributor individually to retrieve this information.

Also refactors some unrelated tests slightly to remove the warning caused by duplicate/non-deterministic parameterized tests:
> This pull request removes 3 and adds 3 tests. Note that renamed tests count towards both.