### PR TITLE
NP-48636 Add handler for creating channel claim

### DIFF
--- a/customer-commons/build.gradle
+++ b/customer-commons/build.gradle
@@ -20,4 +20,6 @@ test{
     environment "API_DOMAIN", "localhost"
     environment "CUSTOMERS_TABLE_NAME","nva_customers"
     environment "ID_NAMESPACE", "https://localhost"
+    environment "API_HOST", "host"
+    environment "PUBLICATION_CHANNEL_PATH", "publication-channels-path"
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
@@ -332,11 +332,15 @@ public class CustomerDto implements Context {
     }
 
     public List<ChannelClaimDto> getChannelClaims() {
-        return channelClaims;
+        return nonNull(channelClaims) ? channelClaims : new ArrayList<>();
     }
 
     public void setChannelClaims(List<ChannelClaimDto> channelClaims) {
         this.channelClaims = channelClaims;
+    }
+
+    public void addChannelClaim(ChannelClaimDto channelClaim) {
+        getChannelClaims().add(channelClaim);
     }
 
     @Override

--- a/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/CustomerDto.java
@@ -332,7 +332,7 @@ public class CustomerDto implements Context {
     }
 
     public List<ChannelClaimDto> getChannelClaims() {
-        return nonNull(channelClaims) ? channelClaims : new ArrayList<>();
+        return nonNull(channelClaims) ? channelClaims : Collections.emptyList();
     }
 
     public void setChannelClaims(List<ChannelClaimDto> channelClaims) {
@@ -340,7 +340,7 @@ public class CustomerDto implements Context {
     }
 
     public void addChannelClaim(ChannelClaimDto channelClaim) {
-        getChannelClaims().add(channelClaim);
+        this.channelClaims.add(channelClaim);
     }
 
     @Override

--- a/customer-commons/src/main/java/no/unit/nva/customer/service/CustomerService.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/service/CustomerService.java
@@ -1,13 +1,14 @@
 package no.unit.nva.customer.service;
 
-import no.unit.nva.customer.exception.InputException;
-import no.unit.nva.customer.model.CustomerDto;
-import nva.commons.apigateway.exceptions.ConflictException;
-import nva.commons.apigateway.exceptions.NotFoundException;
-
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
+import no.unit.nva.customer.exception.InputException;
+import no.unit.nva.customer.model.ChannelClaimDto;
+import no.unit.nva.customer.model.CustomerDto;
+import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.ConflictException;
+import nva.commons.apigateway.exceptions.NotFoundException;
 
 public interface CustomerService {
 
@@ -27,4 +28,7 @@ public interface CustomerService {
 
     List<CustomerDto> refreshCustomers();
 
+    void createChannelClaim(UUID customerIdentifier, ChannelClaimDto channelClaim) throws NotFoundException,
+                                                                                          InputException,
+                                                                                          BadRequestException;
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
@@ -1,5 +1,6 @@
 package no.unit.nva.customer.service.impl;
 
+import static java.util.Objects.isNull;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 import java.time.Instant;
@@ -137,10 +138,10 @@ public class DynamoDBCustomerService implements CustomerService {
     }
 
     private void validateChannelClaim(ChannelClaimDto channelClaim) throws BadRequestException {
-        if (channelClaim == null) {
+        if (isNull(channelClaim)) {
             throw new BadRequestException(CHANNEL_CLAIM_CANNOT_BE_NULL);
         }
-        if (channelClaim.channel() == null) {
+        if (isNull(channelClaim.channel())) {
             throw new BadRequestException(CHANNEL_REQUIRED);
         }
         if (!isPublicationChannel(channelClaim.channel())) {

--- a/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
@@ -1,9 +1,19 @@
 package no.unit.nva.customer.service.impl;
 
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import no.unit.nva.customer.exception.InputException;
+import no.unit.nva.customer.model.ChannelClaimDto;
 import no.unit.nva.customer.model.CustomerDao;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.service.CustomerService;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.Environment;
@@ -18,32 +28,24 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-import java.net.URI;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static nva.commons.core.attempt.Try.attempt;
-
-
 public class DynamoDBCustomerService implements CustomerService {
 
     public static final String BY_ORG_DOMAIN_INDEX_NAME = "byOrgDomain";
-    public static final String CUSTOMER_NOT_FOUND = "Customer not found: ";
     public static final String IDENTIFIERS_NOT_EQUAL = "Identifier in request parameters '%s' "
-        + "is not equal to identifier in customer object '%s'";
+                                                       + "is not equal to identifier in customer object '%s'";
     public static final String BY_CRISTIN_ID_INDEX_NAME = "byCristinId";
-
-    public static final String DYNAMODB_WARMUP_PROBLEM = "There was a problem during describe table to warm up "
-        + "DynamoDB connection";
-    public static final String CUSTOMER_ALREADY_EXISTS_ERROR = "Customer with Institution ID %s already exists.";
+    public static final String INVALID_CHANNEL_MESSAGE = "%s is not a valid channel";
+    public static final String CHANNEL_CLAIM_CANNOT_BE_NULL = "ChannelClaim cannot be null";
+    private static final String CUSTOMER_NOT_FOUND = "Customer not found: ";
+    private static final String DYNAMODB_WARMUP_PROBLEM = "There was a problem during describe table to warm up "
+                                                          + "DynamoDB connection";
+    private static final String CUSTOMER_ALREADY_EXISTS_ERROR = "Customer with Institution ID %s already exists.";
+    private static final String PUBLICATION_CHANNEL_PATH = "PUBLICATION_CHANNEL_PATH";
+    private static final String API_HOST = "API_HOST";
     private static final Environment ENVIRONMENT = new Environment();
     public static final String CUSTOMERS_TABLE_NAME = ENVIRONMENT.readEnv("CUSTOMERS_TABLE_NAME");
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBCustomerService.class);
-
+    private static final String CHANNEL_REQUIRED = "Channel required";
     private final DynamoDbTable<CustomerDao> table;
 
     /**
@@ -61,19 +63,6 @@ public class DynamoDBCustomerService implements CustomerService {
         warmupDynamoDbConnection(table);
     }
 
-    private void warmupDynamoDbConnection(DynamoDbTable<CustomerDao> table) {
-        try {
-            table.describeTable();
-        } catch (Exception e) {
-            logger.warn(DYNAMODB_WARMUP_PROBLEM, e);
-        }
-    }
-
-    private static DynamoDbTable<CustomerDao> createTable(DynamoDbClient client) {
-        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
-        return enhancedClient.table(CUSTOMERS_TABLE_NAME, CustomerDao.TABLE_SCHEMA);
-    }
-
     @Override
     public CustomerDto getCustomer(URI customerId) throws NotFoundException {
         var customerIdentifier = UriWrapper.fromUri(customerId).getLastPathElement();
@@ -83,9 +72,9 @@ public class DynamoDBCustomerService implements CustomerService {
     @Override
     public CustomerDto getCustomer(UUID identifier) throws NotFoundException {
         return Optional.of(CustomerDao.builder().withIdentifier(identifier).build())
-            .map(table::getItem)
-            .map(CustomerDao::toCustomerDto)
-            .orElseThrow(() -> notFoundException(identifier.toString()));
+                   .map(table::getItem)
+                   .map(CustomerDao::toCustomerDto)
+                   .orElseThrow(() -> notFoundException(identifier.toString()));
     }
 
     @Override
@@ -97,10 +86,10 @@ public class DynamoDBCustomerService implements CustomerService {
     @Override
     public List<CustomerDto> getCustomers() {
         return table.scan()
-            .stream()
-            .flatMap(page -> page.items().stream())
-            .map(CustomerDao::toCustomerDto)
-            .collect(Collectors.toList());
+                   .stream()
+                   .flatMap(page -> page.items().stream())
+                   .map(CustomerDao::toCustomerDto)
+                   .collect(Collectors.toList());
     }
 
     @Override
@@ -128,9 +117,49 @@ public class DynamoDBCustomerService implements CustomerService {
     @Override
     public List<CustomerDto> refreshCustomers() {
         return table.scan().items().stream()
-            .map(CustomerDao::toCustomerDto)
-            .map(this::refreshCustomer)
-            .collect(Collectors.toList());
+                   .map(CustomerDao::toCustomerDto)
+                   .map(this::refreshCustomer)
+                   .collect(Collectors.toList());
+    }
+
+    @Override
+    public void createChannelClaim(UUID customerIdentifier, ChannelClaimDto channelClaim)
+        throws NotFoundException, InputException, BadRequestException {
+        validateChannelClaim(channelClaim);
+        var customer = getCustomer(customerIdentifier);
+        customer.addChannelClaim(channelClaim);
+        updateCustomer(customerIdentifier, customer);
+    }
+
+    private static DynamoDbTable<CustomerDao> createTable(DynamoDbClient client) {
+        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
+        return enhancedClient.table(CUSTOMERS_TABLE_NAME, CustomerDao.TABLE_SCHEMA);
+    }
+
+    private void validateChannelClaim(ChannelClaimDto channelClaim) throws BadRequestException {
+        if (channelClaim == null) {
+            throw new BadRequestException(CHANNEL_CLAIM_CANNOT_BE_NULL);
+        }
+        if (channelClaim.channel() == null) {
+            throw new BadRequestException(CHANNEL_REQUIRED);
+        }
+        if (!isPublicationChannel(channelClaim.channel())) {
+            throw new BadRequestException(INVALID_CHANNEL_MESSAGE.formatted(channelClaim.channel()));
+        }
+    }
+
+    private boolean isPublicationChannel(URI channelId) {
+        var host = ENVIRONMENT.readEnv(API_HOST);
+        return host.equals(channelId.getHost())
+               && channelId.toString().contains(ENVIRONMENT.readEnv(PUBLICATION_CHANNEL_PATH));
+    }
+
+    private void warmupDynamoDbConnection(DynamoDbTable<CustomerDao> table) {
+        try {
+            table.describeTable();
+        } catch (Exception e) {
+            logger.warn(DYNAMODB_WARMUP_PROBLEM, e);
+        }
     }
 
     private CustomerDto refreshCustomer(CustomerDto customer) {
@@ -165,10 +194,10 @@ public class DynamoDBCustomerService implements CustomerService {
         QueryEnhancedRequest query = createQuery(queryObject, indexPartitionValue);
         var results = table.index(indexName).query(query);
         return results.stream()
-            .flatMap(page -> page.items().stream())
-            .map(CustomerDao::toCustomerDto)
-            .collect(SingletonCollector.tryCollect())
-            .orElseThrow(fail -> notFoundException(queryObject.toString()));
+                   .flatMap(page -> page.items().stream())
+                   .map(CustomerDao::toCustomerDto)
+                   .collect(SingletonCollector.tryCollect())
+                   .orElseThrow(fail -> notFoundException(queryObject.toString()));
     }
 
     private QueryEnhancedRequest createQuery(CustomerDao queryObject,

--- a/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/service/impl/DynamoDBCustomerService.java
@@ -133,7 +133,7 @@ public class DynamoDBCustomerService implements CustomerService {
     }
 
     private static DynamoDbTable<CustomerDao> createTable(DynamoDbClient client) {
-        DynamoDbEnhancedClient enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
+        var enhancedClient = DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();
         return enhancedClient.table(CUSTOMERS_TABLE_NAME, CustomerDao.TABLE_SCHEMA);
     }
 
@@ -144,15 +144,15 @@ public class DynamoDBCustomerService implements CustomerService {
         if (isNull(channelClaim.channel())) {
             throw new BadRequestException(CHANNEL_REQUIRED);
         }
-        if (!isPublicationChannel(channelClaim.channel())) {
+        if (isNotPublicationChannel(channelClaim.channel())) {
             throw new BadRequestException(INVALID_CHANNEL_MESSAGE.formatted(channelClaim.channel()));
         }
     }
 
-    private boolean isPublicationChannel(URI channelId) {
+    private boolean isNotPublicationChannel(URI channelId) {
         var host = ENVIRONMENT.readEnv(API_HOST);
-        return host.equals(channelId.getHost())
-               && channelId.toString().contains(ENVIRONMENT.readEnv(PUBLICATION_CHANNEL_PATH));
+        var publicationChannelPath = ENVIRONMENT.readEnv(PUBLICATION_CHANNEL_PATH);
+        return !host.equals(channelId.getHost()) || !channelId.toString().contains(publicationChannelPath);
     }
 
     private void warmupDynamoDbConnection(DynamoDbTable<CustomerDao> table) {

--- a/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -1,14 +1,29 @@
 package no.unit.nva.customer.testing;
 
+import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
+import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
+import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import no.unit.nva.customer.model.ApplicationDomain;
 import no.unit.nva.customer.model.ChannelClaimDao;
 import no.unit.nva.customer.model.ChannelClaimDto;
 import no.unit.nva.customer.model.ChannelConstraintDao;
 import no.unit.nva.customer.model.ChannelConstraintDto;
 import no.unit.nva.customer.model.ChannelConstraintPolicy;
+import no.unit.nva.customer.model.CustomerDao;
 import no.unit.nva.customer.model.CustomerDao.RightsRetentionStrategyDao;
 import no.unit.nva.customer.model.CustomerDao.ServiceCenterDao;
-import no.unit.nva.customer.model.CustomerDao;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.model.LinkedDataContextUtils;
 import no.unit.nva.customer.model.PublicationInstanceTypes;
@@ -23,23 +38,6 @@ import no.unit.nva.customer.model.interfaces.RightsRetentionStrategy;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 
-import java.net.URI;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static no.unit.nva.hamcrest.DoesNotHaveEmptyValues.doesNotHaveEmptyValuesIgnoringFields;
-import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
-import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
-import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 public class CustomerDataGenerator {
 
     private static final String API_DOMAIN = new Environment().readEnv("API_DOMAIN");
@@ -49,32 +47,32 @@ public class CustomerDataGenerator {
         UUID identifier = UUID.randomUUID();
         URI id = LinkedDataContextUtils.toId(identifier);
         CustomerDto customer = CustomerDto.builder()
-                .withName(randomString())
-                .withCristinId(randomUri())
-                .withCustomerOf(randomApplicationDomain())
-                .withFeideOrganizationDomain(randomString())
-                .withModifiedDate(randomInstant())
-                .withIdentifier(identifier)
-                .withId(id)
-                .withCname(randomString())
-                .withContext(LinkedDataContextUtils.LINKED_DATA_CONTEXT_VALUE)
-                .withArchiveName(randomString())
-                .withShortName(randomString())
-                .withInstitutionDns(randomString())
-                .withDisplayName(randomString())
-                .withCreatedDate(randomInstant())
-                .withVocabularies(randomVocabularyDtoSettings())
-                .withRorId(randomUri())
-                .withPublicationWorkflow(randomPublicationWorkflow())
-                .withDoiAgent(randomDoiAgent(randomString()))
-                .withSector(randomSector())
-                .withNviInstitution(randomBoolean())
-                .withRboInstitution(randomBoolean())
-                .withInactiveFrom(randomInstant())
-                .withRightsRetentionStrategy(randomRightsRetentionStrategy())
-                .withAllowFileUploadForTypes(randomAllowFileUploadForTypes())
-                .withChannelClaims(randomChannelClaimDtos())
-                .build();
+                                   .withName(randomString())
+                                   .withCristinId(randomUri())
+                                   .withCustomerOf(randomApplicationDomain())
+                                   .withFeideOrganizationDomain(randomString())
+                                   .withModifiedDate(randomInstant())
+                                   .withIdentifier(identifier)
+                                   .withId(id)
+                                   .withCname(randomString())
+                                   .withContext(LinkedDataContextUtils.LINKED_DATA_CONTEXT_VALUE)
+                                   .withArchiveName(randomString())
+                                   .withShortName(randomString())
+                                   .withInstitutionDns(randomString())
+                                   .withDisplayName(randomString())
+                                   .withCreatedDate(randomInstant())
+                                   .withVocabularies(randomVocabularyDtoSettings())
+                                   .withRorId(randomUri())
+                                   .withPublicationWorkflow(randomPublicationWorkflow())
+                                   .withDoiAgent(randomDoiAgent(randomString()))
+                                   .withSector(randomSector())
+                                   .withNviInstitution(randomBoolean())
+                                   .withRboInstitution(randomBoolean())
+                                   .withInactiveFrom(randomInstant())
+                                   .withRightsRetentionStrategy(randomRightsRetentionStrategy())
+                                   .withAllowFileUploadForTypes(randomAllowFileUploadForTypes())
+                                   .withChannelClaims(randomChannelClaimDtos())
+                                   .build();
 
         assertThat(customer, doesNotHaveEmptyValuesIgnoringFields(Set.of("doiAgent.password")));
         return customer;
@@ -85,7 +83,14 @@ public class CustomerDataGenerator {
     }
 
     public static ChannelClaimDto randomChannelClaimDto() {
-        return new ChannelClaimDto(randomUri(), randomChannelConstraintDto());
+        return new ChannelClaimDto(randomChannelId(), randomChannelConstraintDto());
+    }
+
+    public static URI randomChannelId() {
+        var publicationChannelPath = new Environment().readEnv("PUBLICATION_CHANNEL_PATH");
+        return UriWrapper.fromHost(new Environment().readEnv("API_HOST"))
+                   .addChild(publicationChannelPath, randomString())
+                   .getUri();
     }
 
     public static List<ChannelClaimDao> randomChannelClaimDaos() {
@@ -110,29 +115,29 @@ public class CustomerDataGenerator {
 
     public static List<PublicationInstanceTypes> randomScopes() {
         return List.of(
-                randomElement(PublicationInstanceTypes.values()),
-                randomElement(PublicationInstanceTypes.values()),
-                randomElement(PublicationInstanceTypes.values()));
+            randomElement(PublicationInstanceTypes.values()),
+            randomElement(PublicationInstanceTypes.values()),
+            randomElement(PublicationInstanceTypes.values()));
     }
 
     public static Set<VocabularyDto> randomVocabularyDtoSettings() {
         VocabularyDao vocabulary = randomVocabularyDao();
         return Stream.of(vocabulary)
-                .map(VocabularyDao::toVocabularySettingsDto)
-                .collect(Collectors.toSet());
+                   .map(VocabularyDao::toVocabularySettingsDto)
+                   .collect(Collectors.toSet());
     }
 
     public static VocabularyDao randomVocabularyDao() {
         return new VocabularyDao(randomString(), randomUri(),
-                randomElement(VocabularyStatus.values()));
+                                 randomElement(VocabularyStatus.values()));
     }
 
     public static RightsRetentionStrategy randomRightsRetentionStrategy() {
         var elements = Arrays.stream(RightsRetentionStrategyType.values())
-                .filter(f -> f.ordinal() > 0)
-                .collect(Collectors.toList());
+                           .filter(f -> f.ordinal() > 0)
+                           .collect(Collectors.toList());
         return
-                new RightsRetentionStrategyDao(randomElement(elements), randomUri());
+            new RightsRetentionStrategyDao(randomElement(elements), randomUri());
     }
 
     public static DoiAgent randomDoiAgent(String randomString) {
@@ -165,15 +170,11 @@ public class CustomerDataGenerator {
 
     public static Set<PublicationInstanceTypes> randomAllowFileUploadForTypes() {
         return new HashSet<>(Arrays.asList(randomAllowFileUploadForTypesDto(), randomAllowFileUploadForTypesDto(),
-                randomAllowFileUploadForTypesDto()));
+                                           randomAllowFileUploadForTypesDto()));
     }
 
     public static PublicationInstanceTypes randomAllowFileUploadForTypesDto() {
         return randomElement(PublicationInstanceTypes.values());
-    }
-
-    private static ApplicationDomain randomApplicationDomain() {
-        return ApplicationDomain.NVA;
     }
 
     public static CustomerDao createSampleActiveCustomerDao() {
@@ -185,31 +186,31 @@ public class CustomerDataGenerator {
     public static CustomerDao createSampleInactiveCustomerDao() {
         VocabularyDao vocabulary = randomVocabularyDao();
         CustomerDao customer = CustomerDao.builder()
-                .withIdentifier(randomIdentifier())
-                .withName(randomString())
-                .withModifiedDate(randomInstant())
-                .withShortName(randomString())
-                .withCristinId(randomUri())
-                .withCustomerOf(randomApplicationDomainUri())
-                .withVocabularySettings(Set.of(vocabulary))
-                .withInstitutionDns(randomString())
-                .withFeideOrganizationDomain(randomString())
-                .withDisplayName(randomString())
-                .withCreatedDate(randomInstant())
-                .withCname(randomString())
-                .withArchiveName(randomString())
-                .withRorId(randomUri())
-                .withServiceCenter(new ServiceCenterDao(randomUri(), randomString()))
-                .withPublicationWorkflow(randomPublicationWorkflow())
-                .withDoiAgent(randomDoiAgent(randomString()))
-                .withNviInstitution(randomBoolean())
-                .withSector(randomSector())
-                .withInactiveFrom(randomInstant())
-                .withRightsRetentionStrategy(randomRightsRetentionStrategy())
-                .withAllowFileUploadForTypes(randomAllowFileUploadForTypes())
-                .withGeneralSupportEnabled(true)
-                .withChannelClaims(randomChannelClaimDaos())
-                .build();
+                                   .withIdentifier(randomIdentifier())
+                                   .withName(randomString())
+                                   .withModifiedDate(randomInstant())
+                                   .withShortName(randomString())
+                                   .withCristinId(randomUri())
+                                   .withCustomerOf(randomApplicationDomainUri())
+                                   .withVocabularySettings(Set.of(vocabulary))
+                                   .withInstitutionDns(randomString())
+                                   .withFeideOrganizationDomain(randomString())
+                                   .withDisplayName(randomString())
+                                   .withCreatedDate(randomInstant())
+                                   .withCname(randomString())
+                                   .withArchiveName(randomString())
+                                   .withRorId(randomUri())
+                                   .withServiceCenter(new ServiceCenterDao(randomUri(), randomString()))
+                                   .withPublicationWorkflow(randomPublicationWorkflow())
+                                   .withDoiAgent(randomDoiAgent(randomString()))
+                                   .withNviInstitution(randomBoolean())
+                                   .withSector(randomSector())
+                                   .withInactiveFrom(randomInstant())
+                                   .withRightsRetentionStrategy(randomRightsRetentionStrategy())
+                                   .withAllowFileUploadForTypes(randomAllowFileUploadForTypes())
+                                   .withGeneralSupportEnabled(true)
+                                   .withChannelClaims(randomChannelClaimDaos())
+                                   .build();
         assertThat(customer, doesNotHaveEmptyValuesIgnoringFields(Set.of("doiAgent.password")));
         return customer;
     }
@@ -224,9 +225,9 @@ public class CustomerDataGenerator {
 
     public static URI randomCristinOrgId() {
         return new UriWrapper("https", API_DOMAIN)
-                .addChild(CRISTIN_PATH)
-                .addChild(randomString())
-                .getUri();
+                   .addChild(CRISTIN_PATH)
+                   .addChild(randomString())
+                   .getUri();
     }
 
     public static List<VocabularyDto> randomVocabularies() {
@@ -235,7 +236,11 @@ public class CustomerDataGenerator {
 
     public static VocabularyDto randomVocabularyDto() {
         return new VocabularyDto(randomString(), randomUri(),
-                randomElement(VocabularyStatus.values()));
+                                 randomElement(VocabularyStatus.values()));
+    }
+
+    private static ApplicationDomain randomApplicationDomain() {
+        return ApplicationDomain.NVA;
     }
 }
 

--- a/customer/build.gradle
+++ b/customer/build.gradle
@@ -23,4 +23,6 @@ test {
     environment "CUSTOMERS_TABLE_NAME", "nva_customers"
     environment "ID_NAMESPACE", "https://localhost"
     environment "ALLOWED_ORIGIN", "*"
+    environment "API_HOST", "host"
+    environment "PUBLICATION_CHANNEL_PATH", "publication-channels-path"
 }

--- a/customer/src/main/java/no/unit/nva/customer/create/ChannelClaimRequest.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/ChannelClaimRequest.java
@@ -5,10 +5,6 @@ import no.unit.nva.customer.model.ChannelClaimDto;
 
 public record ChannelClaimRequest(URI channel, ChannelConstraintRequest channelConstraintRequest) {
 
-    public static ChannelClaimRequest fromDto(ChannelClaimDto dto) {
-        return new ChannelClaimRequest(dto.channel(), ChannelConstraintRequest.fromDto(dto.constraint()));
-    }
-
     public ChannelClaimDto toDto() {
         return new ChannelClaimDto(channel(), channelConstraintRequest().toDto());
     }

--- a/customer/src/main/java/no/unit/nva/customer/create/ChannelClaimRequest.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/ChannelClaimRequest.java
@@ -1,0 +1,15 @@
+package no.unit.nva.customer.create;
+
+import java.net.URI;
+import no.unit.nva.customer.model.ChannelClaimDto;
+
+public record ChannelClaimRequest(URI channel, ChannelConstraintRequest channelConstraintRequest) {
+
+    public static ChannelClaimRequest fromDto(ChannelClaimDto dto) {
+        return new ChannelClaimRequest(dto.channel(), ChannelConstraintRequest.fromDto(dto.constraint()));
+    }
+
+    public ChannelClaimDto toDto() {
+        return new ChannelClaimDto(channel(), channelConstraintRequest().toDto());
+    }
+}

--- a/customer/src/main/java/no/unit/nva/customer/create/ChannelConstraintRequest.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/ChannelConstraintRequest.java
@@ -1,0 +1,19 @@
+package no.unit.nva.customer.create;
+
+import java.util.List;
+import no.unit.nva.customer.model.ChannelConstraintDto;
+import no.unit.nva.customer.model.ChannelConstraintPolicy;
+import no.unit.nva.customer.model.PublicationInstanceTypes;
+
+public record ChannelConstraintRequest(ChannelConstraintPolicy publishingPolicy,
+                                       ChannelConstraintPolicy editingPolicy,
+                                       List<PublicationInstanceTypes> scope) {
+
+    public static ChannelConstraintRequest fromDto(ChannelConstraintDto dto) {
+        return new ChannelConstraintRequest(dto.publishingPolicy(), dto.editingPolicy(), dto.scope());
+    }
+
+    public ChannelConstraintDto toDto() {
+        return new ChannelConstraintDto(publishingPolicy(), editingPolicy(), scope());
+    }
+}

--- a/customer/src/main/java/no/unit/nva/customer/create/ChannelConstraintRequest.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/ChannelConstraintRequest.java
@@ -9,10 +9,6 @@ public record ChannelConstraintRequest(ChannelConstraintPolicy publishingPolicy,
                                        ChannelConstraintPolicy editingPolicy,
                                        List<PublicationInstanceTypes> scope) {
 
-    public static ChannelConstraintRequest fromDto(ChannelConstraintDto dto) {
-        return new ChannelConstraintRequest(dto.publishingPolicy(), dto.editingPolicy(), dto.scope());
-    }
-
     public ChannelConstraintDto toDto() {
         return new ChannelConstraintDto(publishingPolicy(), editingPolicy(), scope());
     }

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -11,9 +11,9 @@ import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.ForbiddenException;
-import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.paths.UriWrapper;
 
 public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimRequest, Void> {
 
@@ -52,12 +52,12 @@ public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimReq
         return HttpURLConnection.HTTP_CREATED;
     }
 
-    private boolean userIsAuthorizedOnCustomer(RequestInfo requestInfo) throws UnauthorizedException,
-                                                                               NotFoundException {
-        var customerFromPath = customerService.getCustomer(extractIdentifierFromPath(requestInfo));
-        var customerFromUser = customerService.getCustomer(requestInfo.getCurrentCustomer());
+    private boolean userIsAuthorizedOnCustomer(RequestInfo requestInfo) throws UnauthorizedException {
+        var customerIdentifierFromPath = extractIdentifierFromPath(requestInfo).toString();
+        var customerIdentifierFromUser = UriWrapper.fromUri(requestInfo.getCurrentCustomer()).getLastPathElement();
 
-        return customerFromPath.equals(customerFromUser) && requestInfo.userIsAuthorized(MANAGE_CHANNEL_CLAIMS);
+        return customerIdentifierFromPath.equals(customerIdentifierFromUser)
+               && requestInfo.userIsAuthorized(MANAGE_CHANNEL_CLAIMS);
     }
 
     private UUID extractIdentifierFromPath(RequestInfo requestInfo) {

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -17,7 +17,7 @@ import nva.commons.core.paths.UriWrapper;
 
 public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimRequest, Void> {
 
-    public static final String IDENTIFIER_PARAMETER = "identifier";
+    private static final String IDENTIFIER_PARAMETER = "identifier";
     private final CustomerService customerService;
 
     @JacocoGenerated

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -1,0 +1,68 @@
+package no.unit.nva.customer.create;
+
+import static no.unit.nva.customer.Constants.defaultCustomerService;
+import static nva.commons.apigateway.AccessRight.MANAGE_CHANNEL_CLAIMS;
+import com.amazonaws.services.lambda.runtime.Context;
+import java.net.HttpURLConnection;
+import java.util.UUID;
+import no.unit.nva.customer.RequestUtils;
+import no.unit.nva.customer.service.CustomerService;
+import nva.commons.apigateway.ApiGatewayHandler;
+import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.ForbiddenException;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.core.JacocoGenerated;
+
+public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimRequest, Void> {
+
+    public static final String IDENTIFIER_PARAMETER = "identifier";
+    private final CustomerService customerService;
+
+    @JacocoGenerated
+    public CreateChannelClaimHandler() {
+        this(defaultCustomerService());
+    }
+
+    public CreateChannelClaimHandler(CustomerService customerService) {
+        super(ChannelClaimRequest.class);
+        this.customerService = customerService;
+    }
+
+    @Override
+    protected void validateRequest(ChannelClaimRequest channelClaimRequest, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        if (userIsAuthorizedOnCustomer(requestInfo)) {
+            return;
+        }
+        throw new ForbiddenException();
+    }
+
+    @Override
+    protected Void processInput(ChannelClaimRequest channelClaimRequest, RequestInfo requestInfo, Context context)
+        throws ApiGatewayException {
+        var customerIdentifier = extractIdentifierFromPath(requestInfo);
+        customerService.createChannelClaim(customerIdentifier, channelClaimRequest.toDto());
+        return null;
+    }
+
+    @Override
+    protected Integer getSuccessStatusCode(ChannelClaimRequest channelClaimRequest, Void o) {
+        return HttpURLConnection.HTTP_CREATED;
+    }
+
+    private boolean userIsAuthorizedOnCustomer(RequestInfo requestInfo) throws UnauthorizedException,
+                                                                               NotFoundException {
+        var customerFromPath = customerService.getCustomer(extractIdentifierFromPath(requestInfo));
+        var customerFromUser = customerService.getCustomer(requestInfo.getCurrentCustomer());
+
+        return customerFromPath.equals(customerFromUser) && requestInfo.userIsAuthorized(MANAGE_CHANNEL_CLAIMS);
+    }
+
+    private UUID extractIdentifierFromPath(RequestInfo requestInfo) {
+        return RequestUtils.getPathParameter(requestInfo, IDENTIFIER_PARAMETER)
+                   .map(UUID::fromString)
+                   .orElseThrow();
+    }
+}

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
@@ -1,0 +1,142 @@
+package no.unit.nva.customer.create;
+
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.customer.testing.CustomerDataGenerator.createSampleCustomerDto;
+import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelClaimDto;
+import static nva.commons.apigateway.AccessRight.MANAGE_CHANNEL_CLAIMS;
+import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.UUID;
+import no.unit.nva.customer.model.ChannelClaimDto;
+import no.unit.nva.customer.model.CustomerDto;
+import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
+import no.unit.nva.customer.testing.LocalCustomerServiceDatabase;
+import no.unit.nva.stubs.FakeContext;
+import no.unit.nva.testutils.HandlerRequestBuilder;
+import nva.commons.apigateway.GatewayResponse;
+import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.ConflictException;
+import nva.commons.apigateway.exceptions.NotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
+
+    private static final String IDENTIFIER_PATH_PARAMETER = "identifier";
+    private CreateChannelClaimHandler handler;
+    private Context context;
+    private ByteArrayOutputStream outputSteam;
+    private DynamoDBCustomerService customerService;
+    private CustomerDto existingCustomer;
+
+    @BeforeEach
+    public void setUp() throws ApiGatewayException {
+        super.setupDatabase();
+        this.customerService = new DynamoDBCustomerService(this.dynamoClient);
+        existingCustomer = customerService.createCustomer(createSampleCustomerDto());
+        handler = new CreateChannelClaimHandler(customerService);
+        context = new FakeContext();
+        outputSteam = new ByteArrayOutputStream();
+    }
+
+    @AfterEach
+    public void close() {
+        super.deleteDatabase();
+    }
+
+    @Test
+    void shouldReturnCreatedWhenCreatingChannelClaim() throws IOException {
+        var request = createValidRequest();
+        handler.handleRequest(request, outputSteam, context);
+        var response = GatewayResponse.fromOutputStream(outputSteam, ChannelClaimDto.class);
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CREATED)));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenCustomerDoesNotExist() throws IOException {
+        var request = createRequestWithNonExistingCustomer();
+        handler.handleRequest(request, outputSteam, context);
+        var response = GatewayResponse.fromOutputStream(outputSteam, ChannelClaimDto.class);
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenCreatingChannelClaimForAnotherCustomer()
+        throws IOException, ConflictException, NotFoundException {
+        var request = createRequestWithUserNotBelongingToCustomer();
+        handler.handleRequest(request, outputSteam, context);
+        var response = GatewayResponse.fromOutputStream(outputSteam, ChannelClaimDto.class);
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_FORBIDDEN)));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenCreatingChannelClaimWithoutAccessRight() throws IOException {
+        var request = createRequestWithoutAccessRights();
+        handler.handleRequest(request, outputSteam, context);
+        var response = GatewayResponse.fromOutputStream(outputSteam, ChannelClaimDto.class);
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_FORBIDDEN)));
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenCreatingChannelClaimWithWrongAccessRight() throws IOException {
+        var request = createRequestWithWrongAccessRight();
+        handler.handleRequest(request, outputSteam, context);
+        var response = GatewayResponse.fromOutputStream(outputSteam, ChannelClaimDto.class);
+        assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_FORBIDDEN)));
+    }
+
+    private HandlerRequestBuilder<ChannelClaimRequest> createDefaultRequestBuilder(UUID customerToClaim,
+                                                                                   ChannelClaimRequest channelClaim)
+        throws JsonProcessingException {
+        return new HandlerRequestBuilder<ChannelClaimRequest>(dtoObjectMapper)
+                   .withPathParameters(Map.of(IDENTIFIER_PATH_PARAMETER, customerToClaim.toString()))
+                   .withCurrentCustomer(existingCustomer.getId())
+                   .withBody(channelClaim);
+    }
+
+    private InputStream createValidRequest() throws JsonProcessingException {
+        return createDefaultRequestBuilder(existingCustomer.getIdentifier(), randomChannelClaimRequest())
+                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .build();
+    }
+
+    private InputStream createRequestWithNonExistingCustomer() throws JsonProcessingException {
+        var nonExistingCustomerIdentifier = UUID.randomUUID();
+        return createDefaultRequestBuilder(nonExistingCustomerIdentifier, randomChannelClaimRequest())
+                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .build();
+    }
+
+    private InputStream createRequestWithUserNotBelongingToCustomer()
+        throws JsonProcessingException, ConflictException, NotFoundException {
+        var anotherCustomer = customerService.createCustomer(createSampleCustomerDto());
+        return createDefaultRequestBuilder(anotherCustomer.getIdentifier(), randomChannelClaimRequest())
+                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .build();
+    }
+
+    private InputStream createRequestWithoutAccessRights() throws JsonProcessingException {
+        return createDefaultRequestBuilder(existingCustomer.getIdentifier(), randomChannelClaimRequest())
+                   .build();
+    }
+
+    private InputStream createRequestWithWrongAccessRight() throws JsonProcessingException {
+        return createDefaultRequestBuilder(existingCustomer.getIdentifier(), randomChannelClaimRequest())
+                   .withAccessRights(existingCustomer.getId(), MANAGE_DOI)
+                   .build();
+    }
+
+    private ChannelClaimRequest randomChannelClaimRequest() {
+        return ChannelClaimRequest.fromDto(randomChannelClaimDto());
+    }
+}

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
@@ -3,6 +3,7 @@ package no.unit.nva.customer.create;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.createSampleCustomerDto;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelClaimDto;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.apigateway.AccessRight.MANAGE_CHANNEL_CLAIMS;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -26,6 +27,7 @@ import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.ConflictException;
 import nva.commons.apigateway.exceptions.NotFoundException;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,7 +114,11 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
 
     private InputStream createRequestWithNonExistingCustomer() throws JsonProcessingException {
         var nonExistingCustomerIdentifier = UUID.randomUUID();
+        var nonExistingCustomerId = UriWrapper.fromHost(randomString())
+                                        .addChild(nonExistingCustomerIdentifier.toString())
+                                        .getUri();
         return createDefaultRequestBuilder(nonExistingCustomerIdentifier, randomChannelClaimRequest())
+                   .withCurrentCustomer(nonExistingCustomerId)
                    .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
                    .build();
     }

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection;
 import java.util.Map;
 import java.util.UUID;
 import no.unit.nva.customer.model.ChannelClaimDto;
+import no.unit.nva.customer.model.ChannelConstraintDto;
 import no.unit.nva.customer.model.CustomerDto;
 import no.unit.nva.customer.service.impl.DynamoDBCustomerService;
 import no.unit.nva.customer.testing.LocalCustomerServiceDatabase;
@@ -143,6 +144,14 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
     }
 
     private ChannelClaimRequest randomChannelClaimRequest() {
-        return ChannelClaimRequest.fromDto(randomChannelClaimDto());
+        return fromDto(randomChannelClaimDto());
+    }
+
+    private ChannelClaimRequest fromDto(ChannelClaimDto dto) {
+        return new ChannelClaimRequest(dto.channel(), fromDto(dto.constraint()));
+    }
+
+    private ChannelConstraintRequest fromDto(ChannelConstraintDto dto) {
+        return new ChannelConstraintRequest(dto.publishingPolicy(), dto.editingPolicy(), dto.scope());
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-nvaCommons = { strictly = '1.41.8' }
+nvaCommons = { strictly = '2.1.1' }
 # require awsSdk because of xraySdk using version 1.11.1000 and us using newer version.
 #awsSdk = { require = "1.11.1000" }
 awsSdk2 = { strictly = '2.30.27' }


### PR DESCRIPTION
Sorry in advance for formatting changes - installed and used scheme UnitStyle.xml. I have only updated things regarding channel claims. 

Have created CreateChannelClaimHandler and ChannelClaim-methods in CustomerService. The handler validates the request, and the CustomerService creates a channel claim and adds it to a Customer. There is some validation in the service to make sure the dto is not empty, and that the channel to be claimed is a legit uri. 

There is still no validation to ensure that a channel is not already claimed. Have to create indexes in the DB to check for this. Have created tasks for this (NP-48830 and NP-48831). 

The template (and Swagger) will be updated in another PR (NP-48829).

Updated commons version to use the new access right `MANAGE_CHANNEL_CLAIMS`.