### PR TITLE
Use MANAGE_RESOURCE_ALL instead of MANAGE_CHANNEL_CLAIMS as workaround

### DIFF
--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -1,7 +1,7 @@
 package no.unit.nva.customer.create;
 
 import static no.unit.nva.customer.Constants.defaultCustomerService;
-import static nva.commons.apigateway.AccessRight.MANAGE_CHANNEL_CLAIMS;
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.UUID;
@@ -57,7 +57,7 @@ public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimReq
         var customerIdentifierFromUser = UriWrapper.fromUri(requestInfo.getCurrentCustomer()).getLastPathElement();
 
         return customerIdentifierFromPath.equals(customerIdentifierFromUser)
-               && requestInfo.userIsAuthorized(MANAGE_CHANNEL_CLAIMS);
+               && requestInfo.userIsAuthorized(MANAGE_RESOURCES_ALL);
     }
 
     private UUID extractIdentifierFromPath(RequestInfo requestInfo) {

--- a/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
+++ b/customer/src/test/java/no/unit/nva/customer/create/CreateChannelClaimHandlerTest.java
@@ -6,8 +6,8 @@ import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelCl
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelConstraintDto;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static nva.commons.apigateway.AccessRight.MANAGE_CHANNEL_CLAIMS;
 import static nva.commons.apigateway.AccessRight.MANAGE_DOI;
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -139,7 +139,7 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
 
     private InputStream createValidRequest() throws JsonProcessingException {
         return createDefaultRequestBuilder(existingCustomer.getIdentifier(), randomChannelClaimRequest())
-                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .withAccessRights(existingCustomer.getId(), MANAGE_RESOURCES_ALL)
                    .build();
     }
 
@@ -150,7 +150,7 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
                                         .getUri();
         return createDefaultRequestBuilder(nonExistingCustomerIdentifier, randomChannelClaimRequest())
                    .withCurrentCustomer(nonExistingCustomerId)
-                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .withAccessRights(existingCustomer.getId(), MANAGE_RESOURCES_ALL)
                    .build();
     }
 
@@ -158,7 +158,7 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
         throws JsonProcessingException, ConflictException, NotFoundException {
         var anotherCustomer = customerService.createCustomer(createSampleCustomerDto());
         return createDefaultRequestBuilder(anotherCustomer.getIdentifier(), randomChannelClaimRequest())
-                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .withAccessRights(existingCustomer.getId(), MANAGE_RESOURCES_ALL)
                    .build();
     }
 
@@ -176,7 +176,7 @@ class CreateChannelClaimHandlerTest extends LocalCustomerServiceDatabase {
     private InputStream createRequestWithInvalidChannelUriInBody() throws JsonProcessingException {
         var channelClaimRequest = new ChannelClaimRequest(randomUri(), fromDto(randomChannelConstraintDto()));
         return createDefaultRequestBuilder(existingCustomer.getIdentifier(), channelClaimRequest)
-                   .withAccessRights(existingCustomer.getId(), MANAGE_CHANNEL_CLAIMS)
+                   .withAccessRights(existingCustomer.getId(), MANAGE_RESOURCES_ALL)
                    .build();
     }
 


### PR DESCRIPTION
Until commons can be bumped, use MANAGE_RESOURCE_ALL to authorize POST endpoint for channel claims. Only Editor has this accessRight.