### PR TITLE
NP-48856 Return 409 Conflict when a channel is already claimed

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/service/CustomerService.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/service/CustomerService.java
@@ -33,7 +33,8 @@ public interface CustomerService {
 
     void createChannelClaim(UUID customerIdentifier, ChannelClaimDto channelClaim) throws NotFoundException,
                                                                                           InputException,
-                                                                                          BadRequestException;
+                                                                                          BadRequestException,
+                                                                                          ConflictException;
 
     Collection<ChannelClaimWithClaimer> getChannelClaims();
 

--- a/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDtoTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/model/CustomerDtoTest.java
@@ -155,4 +155,16 @@ class CustomerDtoTest {
         var randomActiveCustomer = randomActiveCustomer();
         assertThat(randomActiveCustomer.isActive(), is(true));
     }
+
+    @Test
+    void shouldNotAddChannelClaimWhenChannelIsAlreadyClaimed() {
+        var customer = randomActiveCustomer();
+        var numberOfClaimsBefore = customer.getChannelClaims().size();
+
+        var alreadyClaimedChannel = customer.getChannelClaims().stream().findFirst().orElseThrow();
+        customer.addChannelClaim(alreadyClaimedChannel);
+        var numberOfClaimsAfter = customer.getChannelClaims().size();
+
+        assertThat(numberOfClaimsAfter, is(equalTo(numberOfClaimsBefore)));
+    }
 }

--- a/customer-commons/src/test/java/no/unit/nva/customer/service/impl/DynamoDBCustomerServiceTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/service/impl/DynamoDBCustomerServiceTest.java
@@ -335,14 +335,22 @@ class DynamoDBCustomerServiceTest extends LocalCustomerServiceDatabase {
     }
 
     @Test
-    void shouldIgnoreTheCreateChannelCLaimWhenTheCustomerAlreadyHaveClaimedTheChannel()
-        throws ConflictException, NotFoundException, InputException, BadRequestException {
+    void shouldThrowConflictExceptionWhenTheCustomerAlreadyHaveClaimedTheChannel() throws ConflictException,
+                                                                                   NotFoundException {
         var existingClaim = randomChannelClaimDto();
         var customer = createCustomerWithChannelClaim(existingClaim);
 
-        service.createChannelClaim(customer.getIdentifier(), existingClaim);
-        var updatedCustomer = service.getCustomer(customer.getIdentifier());
-        assertEquals(1, updatedCustomer.getChannelClaims().size());
+        assertThrows(ConflictException.class, () -> service.createChannelClaim(customer.getIdentifier(), existingClaim));
+    }
+
+    @Test
+    void shouldThrowConflictExceptionWhenAnotherCustomerHasAlreadyClaimedTheChannel() throws ConflictException,
+                                                                                   NotFoundException {
+        var existingClaim = randomChannelClaimDto();
+        createCustomerWithChannelClaim(existingClaim);
+
+        var customer = createCustomerWithoutChannelClaim();
+        assertThrows(ConflictException.class, () -> service.createChannelClaim(customer.getIdentifier(), existingClaim));
     }
 
     @Test

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -45,7 +45,6 @@ public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimReq
         throws ApiGatewayException {
         var customerIdentifier = extractIdentifierFromPath(requestInfo);
         customerService.createChannelClaim(customerIdentifier, request.toDto());
-//        return new ChannelClaimResponse();
         return null;
     }
 

--- a/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
+++ b/customer/src/main/java/no/unit/nva/customer/create/CreateChannelClaimHandler.java
@@ -1,9 +1,9 @@
 package no.unit.nva.customer.create;
 
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static no.unit.nva.customer.Constants.defaultCustomerService;
 import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import com.amazonaws.services.lambda.runtime.Context;
-import java.net.HttpURLConnection;
 import java.util.UUID;
 import no.unit.nva.customer.RequestUtils;
 import no.unit.nva.customer.service.CustomerService;
@@ -32,7 +32,7 @@ public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimReq
     }
 
     @Override
-    protected void validateRequest(ChannelClaimRequest channelClaimRequest, RequestInfo requestInfo, Context context)
+    protected void validateRequest(ChannelClaimRequest request, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
         if (userIsAuthorizedOnCustomer(requestInfo)) {
             return;
@@ -41,16 +41,17 @@ public class CreateChannelClaimHandler extends ApiGatewayHandler<ChannelClaimReq
     }
 
     @Override
-    protected Void processInput(ChannelClaimRequest channelClaimRequest, RequestInfo requestInfo, Context context)
+    protected Void processInput(ChannelClaimRequest request, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
         var customerIdentifier = extractIdentifierFromPath(requestInfo);
-        customerService.createChannelClaim(customerIdentifier, channelClaimRequest.toDto());
+        customerService.createChannelClaim(customerIdentifier, request.toDto());
+//        return new ChannelClaimResponse();
         return null;
     }
 
     @Override
-    protected Integer getSuccessStatusCode(ChannelClaimRequest channelClaimRequest, Void o) {
-        return HttpURLConnection.HTTP_CREATED;
+    protected Integer getSuccessStatusCode(ChannelClaimRequest request, Void response) {
+        return HTTP_CREATED;
     }
 
     private boolean userIsAuthorizedOnCustomer(RequestInfo requestInfo) throws UnauthorizedException {


### PR DESCRIPTION
When a user tries to claim a channel that is already claimed, whether by their customer or another, a `HTTP 409 Conflict` is returned.