### PR TITLE
NP-48959 Only allow default channel constraint

### DIFF
--- a/customer-commons/src/main/java/no/unit/nva/customer/model/channelclaim/ChannelConstraintDao.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/model/channelclaim/ChannelConstraintDao.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.util.Collections.emptyList;
-import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.EVERYONE;
-import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.OWNER_ONLY;
 
 @DynamoDbBean
 public class ChannelConstraintDao implements JsonSerializable {
@@ -19,8 +17,6 @@ public class ChannelConstraintDao implements JsonSerializable {
     private List<PublicationInstanceTypes> scope;
 
     public ChannelConstraintDao() {
-        this.publishingPolicy = EVERYONE;
-        this.editingPolicy = OWNER_ONLY;
         this.scope = emptyList();
     }
 

--- a/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
@@ -10,6 +10,7 @@ import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.EV
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.OWNER_ONLY;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -58,7 +59,7 @@ public final class ChannelClaimValidator {
         if (!isValidPublicationChannel(channelClaim.channel())) {
             throw new BadRequestException(INVALID_CHANNEL_MESSAGE);
         }
-        if (!isDefaultConstraints(channelClaim.constraint())) {
+        if (!isDefaultConstraint(channelClaim.constraint())) {
             throw new BadRequestException(PROVIDED_CONSTRAINT_IS_NOT_ALLOWED);
         }
     }
@@ -90,9 +91,9 @@ public final class ChannelClaimValidator {
     }
 
     // Temporary validation while constraints are restricted
-    private static boolean isDefaultConstraints(ChannelConstraintDto constraint) {
-        return constraint.publishingPolicy().equals(EVERYONE)
-               && constraint.editingPolicy().equals(OWNER_ONLY)
-               && DEGREES.equals(constraint.scope());
+    private static boolean isDefaultConstraint(ChannelConstraintDto constraint) {
+        return EVERYONE.equals(constraint.publishingPolicy())
+               && OWNER_ONLY.equals(constraint.editingPolicy())
+               && new HashSet<>(DEGREES).containsAll(constraint.scope());
     }
 }

--- a/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
@@ -10,9 +10,10 @@ import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.EV
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.OWNER_ONLY;
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import no.unit.nva.customer.model.PublicationInstanceTypes;
 import no.unit.nva.customer.model.channelclaim.ChannelClaimDto;
@@ -38,10 +39,10 @@ public final class ChannelClaimValidator {
     private static final String SLASH = "/";
     private static final String EMPTY_STRING = "";
     private static final int THREE = 3;
-    private static final HashSet<PublicationInstanceTypes> DEGREES = new HashSet<>(
-        List.of(DEGREE_BACHELOR, DEGREE_MASTER, DEGREE_PHD,
-                DEGREE_LICENTIATE, ARTISTIC_DEGREE_PHD,
-                OTHER_STUDENT_WORK));
+    private static final Set<PublicationInstanceTypes> DEGREES = EnumSet.of(DEGREE_BACHELOR, DEGREE_MASTER,
+                                                                            DEGREE_PHD, DEGREE_LICENTIATE,
+                                                                            ARTISTIC_DEGREE_PHD,
+                                                                            OTHER_STUDENT_WORK);
 
     @JacocoGenerated
     public ChannelClaimValidator() {

--- a/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
+++ b/customer-commons/src/main/java/no/unit/nva/customer/validator/ChannelClaimValidator.java
@@ -38,9 +38,10 @@ public final class ChannelClaimValidator {
     private static final String SLASH = "/";
     private static final String EMPTY_STRING = "";
     private static final int THREE = 3;
-    private static final List<PublicationInstanceTypes> DEGREES = List.of(DEGREE_BACHELOR, DEGREE_MASTER, DEGREE_PHD,
-                                                                          DEGREE_LICENTIATE, ARTISTIC_DEGREE_PHD,
-                                                                          OTHER_STUDENT_WORK);
+    private static final HashSet<PublicationInstanceTypes> DEGREES = new HashSet<>(
+        List.of(DEGREE_BACHELOR, DEGREE_MASTER, DEGREE_PHD,
+                DEGREE_LICENTIATE, ARTISTIC_DEGREE_PHD,
+                OTHER_STUDENT_WORK));
 
     @JacocoGenerated
     public ChannelClaimValidator() {
@@ -94,6 +95,6 @@ public final class ChannelClaimValidator {
     private static boolean isDefaultConstraint(ChannelConstraintDto constraint) {
         return EVERYONE.equals(constraint.publishingPolicy())
                && OWNER_ONLY.equals(constraint.editingPolicy())
-               && new HashSet<>(DEGREES).containsAll(constraint.scope());
+               && DEGREES.containsAll(constraint.scope());
     }
 }

--- a/customer-commons/src/test/java/no/unit/nva/customer/validator/ChannelClaimValidatorTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/validator/ChannelClaimValidatorTest.java
@@ -4,7 +4,7 @@ import static no.unit.nva.customer.model.PublicationInstanceTypes.ACADEMIC_ARTIC
 import static no.unit.nva.customer.model.PublicationInstanceTypes.DEGREE_MASTER;
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.EVERYONE;
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.OWNER_ONLY;
-import static no.unit.nva.customer.testing.CustomerDataGenerator.degreeScopes;
+import static no.unit.nva.customer.testing.CustomerDataGenerator.degreeScope;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannel;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelClaimDto;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelConstraintDto;
@@ -76,7 +76,7 @@ class ChannelClaimValidatorTest {
 
     @Test
     void shouldThrowBadRequestExceptionWhenPublishingPolicyIsOwnerOnly() {
-        var nonDefaultConstraint = new ChannelConstraintDto(OWNER_ONLY, OWNER_ONLY, degreeScopes());
+        var nonDefaultConstraint = new ChannelConstraintDto(OWNER_ONLY, OWNER_ONLY, degreeScope());
         var channelClaimWithNotDefaultConstraint = new ChannelClaimDto(randomChannel(), nonDefaultConstraint);
         assertThrows(BadRequestException.class,
                      () -> ChannelClaimValidator.validate(channelClaimWithNotDefaultConstraint));
@@ -84,7 +84,7 @@ class ChannelClaimValidatorTest {
 
     @Test
     void shouldThrowBadRequestExceptionWhenEditingPolicyIsEveryone() {
-        var nonDefaultConstraint = new ChannelConstraintDto(EVERYONE, EVERYONE, degreeScopes());
+        var nonDefaultConstraint = new ChannelConstraintDto(EVERYONE, EVERYONE, degreeScope());
         var channelClaimWithNotDefaultConstraint = new ChannelClaimDto(randomChannel(), nonDefaultConstraint);
         assertThrows(BadRequestException.class,
                      () -> ChannelClaimValidator.validate(channelClaimWithNotDefaultConstraint));

--- a/customer-commons/src/test/java/no/unit/nva/customer/validator/ChannelClaimValidatorTest.java
+++ b/customer-commons/src/test/java/no/unit/nva/customer/validator/ChannelClaimValidatorTest.java
@@ -4,6 +4,7 @@ import static no.unit.nva.customer.model.PublicationInstanceTypes.ACADEMIC_ARTIC
 import static no.unit.nva.customer.model.PublicationInstanceTypes.DEGREE_MASTER;
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.EVERYONE;
 import static no.unit.nva.customer.model.channelclaim.ChannelConstraintPolicy.OWNER_ONLY;
+import static no.unit.nva.customer.testing.CustomerDataGenerator.degreeScopes;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannel;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelClaimDto;
 import static no.unit.nva.customer.testing.CustomerDataGenerator.randomChannelConstraintDto;
@@ -75,7 +76,7 @@ class ChannelClaimValidatorTest {
 
     @Test
     void shouldThrowBadRequestExceptionWhenPublishingPolicyIsOwnerOnly() {
-        var nonDefaultConstraint = new ChannelConstraintDto(OWNER_ONLY, OWNER_ONLY, List.of(DEGREE_MASTER));
+        var nonDefaultConstraint = new ChannelConstraintDto(OWNER_ONLY, OWNER_ONLY, degreeScopes());
         var channelClaimWithNotDefaultConstraint = new ChannelClaimDto(randomChannel(), nonDefaultConstraint);
         assertThrows(BadRequestException.class,
                      () -> ChannelClaimValidator.validate(channelClaimWithNotDefaultConstraint));
@@ -83,7 +84,7 @@ class ChannelClaimValidatorTest {
 
     @Test
     void shouldThrowBadRequestExceptionWhenEditingPolicyIsEveryone() {
-        var nonDefaultConstraint = new ChannelConstraintDto(EVERYONE, EVERYONE, List.of(DEGREE_MASTER));
+        var nonDefaultConstraint = new ChannelConstraintDto(EVERYONE, EVERYONE, degreeScopes());
         var channelClaimWithNotDefaultConstraint = new ChannelClaimDto(randomChannel(), nonDefaultConstraint);
         assertThrows(BadRequestException.class,
                      () -> ChannelClaimValidator.validate(channelClaimWithNotDefaultConstraint));

--- a/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -148,9 +148,9 @@ public final class CustomerDataGenerator {
 
     public static List<PublicationInstanceTypes> degreeScope() {
         return List.of(
-            PublicationInstanceTypes.DEGREE_BACHELOR,
-            PublicationInstanceTypes.DEGREE_MASTER,
             PublicationInstanceTypes.DEGREE_PHD,
+            PublicationInstanceTypes.DEGREE_MASTER,
+            PublicationInstanceTypes.DEGREE_BACHELOR,
             PublicationInstanceTypes.DEGREE_LICENTIATE,
             PublicationInstanceTypes.ARTISTIC_DEGREE_PHD,
             PublicationInstanceTypes.OTHER_STUDENT_WORK);

--- a/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -119,7 +119,7 @@ public final class CustomerDataGenerator {
     }
 
     private static ChannelConstraintDao defaultChannelConstraintDao() {
-        return new ChannelConstraintDao(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScopes());
+        return new ChannelConstraintDao(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScope());
     }
 
     public static ChannelConstraintDto randomChannelConstraintDto() {
@@ -130,7 +130,7 @@ public final class CustomerDataGenerator {
     }
 
     private static ChannelConstraintDto defaultChannelConstraintDto() {
-        return new ChannelConstraintDto(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScopes());
+        return new ChannelConstraintDto(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScope());
     }
 
     // Commented out until restriction of constraints are removed
@@ -146,7 +146,7 @@ public final class CustomerDataGenerator {
     //         randomElement(PublicationInstanceTypes.values()));
     // }
 
-    public static List<PublicationInstanceTypes> degreeScopes() {
+    public static List<PublicationInstanceTypes> degreeScope() {
         return List.of(
             PublicationInstanceTypes.DEGREE_BACHELOR,
             PublicationInstanceTypes.DEGREE_MASTER,

--- a/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
+++ b/customer-testing/src/main/java/no/unit/nva/customer/testing/CustomerDataGenerator.java
@@ -112,22 +112,48 @@ public final class CustomerDataGenerator {
     }
 
     public static ChannelConstraintDao randomChannelConstraintDao() {
-        return new ChannelConstraintDao(randomChannelPolicy(), randomChannelPolicy(), randomScopes());
+        return defaultChannelConstraintDao();
+
+        // Commented out until restriction of constraints are removed
+        // return new ChannelConstraintDao(randomChannelPolicy(), randomChannelPolicy(), randomScopes());
+    }
+
+    private static ChannelConstraintDao defaultChannelConstraintDao() {
+        return new ChannelConstraintDao(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScopes());
     }
 
     public static ChannelConstraintDto randomChannelConstraintDto() {
-        return new ChannelConstraintDto(randomChannelPolicy(), randomChannelPolicy(), randomScopes());
+        return defaultChannelConstraintDto();
+
+        // Commented out until restriction of constraints are removed
+        // return new ChannelConstraintDto(randomChannelPolicy(), randomChannelPolicy(), randomScopes());
     }
 
-    public static ChannelConstraintPolicy randomChannelPolicy() {
-        return randomElement(ChannelConstraintPolicy.values());
+    private static ChannelConstraintDto defaultChannelConstraintDto() {
+        return new ChannelConstraintDto(ChannelConstraintPolicy.EVERYONE, ChannelConstraintPolicy.OWNER_ONLY, degreeScopes());
     }
 
-    public static List<PublicationInstanceTypes> randomScopes() {
+    // Commented out until restriction of constraints are removed
+    // public static ChannelConstraintPolicy randomChannelPolicy() {
+    //    return randomElement(ChannelConstraintPolicy.values());
+    // }
+
+    // Commented out until restriction of constraints are removed
+    // public static List<PublicationInstanceTypes> randomScopes() {
+    //     return List.of(
+    //         randomElement(PublicationInstanceTypes.values()),
+    //         randomElement(PublicationInstanceTypes.values()),
+    //         randomElement(PublicationInstanceTypes.values()));
+    // }
+
+    public static List<PublicationInstanceTypes> degreeScopes() {
         return List.of(
-            randomElement(PublicationInstanceTypes.values()),
-            randomElement(PublicationInstanceTypes.values()),
-            randomElement(PublicationInstanceTypes.values()));
+            PublicationInstanceTypes.DEGREE_BACHELOR,
+            PublicationInstanceTypes.DEGREE_MASTER,
+            PublicationInstanceTypes.DEGREE_PHD,
+            PublicationInstanceTypes.DEGREE_LICENTIATE,
+            PublicationInstanceTypes.ARTISTIC_DEGREE_PHD,
+            PublicationInstanceTypes.OTHER_STUDENT_WORK);
     }
 
     public static Set<VocabularyDto> randomVocabularyDtoSettings() {


### PR DESCRIPTION
The first delivery should only allow a specific set of constraints. `PublishingPolicy` should always be `EVERYONE`, `editingPolicy` should always be `OWNER_ONLY`, and `scope` should always be the six protected degrees.