### PR TITLE
supporting delete method in cors

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -123,7 +123,7 @@ Globals:
         BOT_FILTER_BYPASS_HEADER_VALUE: !Ref CristinBotFilterBypassHeaderValue
   Api:
     Cors:
-      AllowMethods: '''POST, PUT, GET,OPTIONS'''
+      AllowMethods: '''POST, PUT, GET, OPTIONS, DELETE'''
       AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
       AllowOrigin: '''*'''
     OpenApiVersion: 3.0.1


### PR DESCRIPTION
DeleteChannelClaim is first DELETE endpoint in customer-api. Adding `DELETE` method to supported cors methods. 
Otherwise DELETE is not listed in `Access-Control-Allow-Methods` header.