### PR TITLE
Remove deprecation warnings (by fixing them…)

### DIFF
--- a/buildSrc/src/main/groovy/nva.identity.service.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.identity.service.java-common-conventions.gradle
@@ -26,8 +26,8 @@ java {
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
-    maven { url "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
+    maven { url = 'https://jitpack.io' }
+    maven { url = "https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release" }
 }
 
 tasks.named('test') {
@@ -36,7 +36,7 @@ tasks.named('test') {
     }
     failFast = true
     testLogging {
-        events 'skipped', 'passed', 'failed'
+        events = [ 'skipped', 'passed', 'failed' ]
     }
 }
 
@@ -55,7 +55,7 @@ tasks.withType(Checkstyle).configureEach {
     reports {
         xml.required
         html.required
-        html.stylesheet rootProject.resources.text.fromFile('config/checkstyle/checkstyle-simple.xsl')
+        html.stylesheet = rootProject.resources.text.fromFile('config/checkstyle/checkstyle-simple.xsl')
     }
 }
 

--- a/buildSrc/src/main/groovy/nva.identity.service.rootplugin.gradle
+++ b/buildSrc/src/main/groovy/nva.identity.service.rootplugin.gradle
@@ -7,7 +7,7 @@ plugins{
 
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
+    maven { url = 'https://jitpack.io' }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.warning.mode=all


### PR DESCRIPTION
As in other cases, we see the old-style, gradle-specific `property value` assignment, which are now replaced by `property = value`. I also enabled configuration caching.