### PR TITLE
ci: Disable Gradle configuration cache for SAM

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     GRADLE_USER_HOME: '/root/.gradle'
-    GRADLE_OPTS: "-Dorg:gradle:configuration-cache=false"
+    GRADLE_OPTS: "-Dorg.gradle.configuration-cache=false"
     SAM_CLI_TELEMETRY: "0"
 
 cache:

--- a/sam-build.sh
+++ b/sam-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# SAM build wrapper that disables Gradle configuration cache
+# Wrapper script for running `sam build` locally
 export GRADLE_OPTS="-Dorg.gradle.configuration-cache=false"
 sam build "$@"


### PR DESCRIPTION
Disables the new Gradle configuration cache for CI builds because this is not supported by `sam build` yet.