### PR TITLE
fix(user-creation): reject Cristin institution redirects #NP-51008

### DIFF
--- a/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/CristinWireMockStubs.java
+++ b/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/CristinWireMockStubs.java
@@ -1,0 +1,182 @@
+package no.unit.nva.useraccessservice.userceation.testing.cristin;
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import no.unit.nva.commons.json.JsonUtils;
+import no.unit.nva.useraccessservice.usercreation.person.cristin.HttpHeaders;
+import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinInstitution;
+import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinInstitutionUnit;
+import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinPerson;
+import nva.commons.core.paths.UriWrapper;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static nva.commons.core.attempt.Try.attempt;
+
+class CristinWireMockStubs {
+
+    private static final String AUTHORIZATION_HEADER_NAME = "authorization";
+    private static final String PERSONS_RESOLVE_BY_NATIONAL_ID = "/persons/resolve?national_id=%s";
+    private static final String INSTITUTIONS = "/institutions/";
+    private static final String PERSONS = "/persons";
+    private final String basicAuthorizationHeaderValue;
+    private final HttpHeaders defaultRequestHeaders;
+    private URI cristinBaseUri;
+
+    CristinWireMockStubs(String basicAuthorizationHeaderValue,
+                         URI cristinBaseUri,
+                         HttpHeaders defaultRequestHeaders) {
+        this.basicAuthorizationHeaderValue = basicAuthorizationHeaderValue;
+        this.cristinBaseUri = cristinBaseUri;
+        this.defaultRequestHeaders = defaultRequestHeaders;
+    }
+
+    void setCristinBaseUri(URI cristinBaseUri) {
+        this.cristinBaseUri = cristinBaseUri;
+    }
+
+    void createPersonSearchStubBadGateway(String nin) {
+        stubWithDefaultRequestHeaders(
+            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_BAD_GATEWAY)));
+    }
+
+    void createPersonSearchStubIllegalJson(String nin) {
+        var illegalBodyAsObjectIsExpected = "[]";
+
+        stubWithDefaultRequestHeaders(
+            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withBody(illegalBodyAsObjectIsExpected)
+                    .withStatus(HttpURLConnection.HTTP_OK)));
+    }
+
+    void createStubsForPerson(String nin, CristinPerson cristinPerson) {
+        var response = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinPerson))
+            .orElseThrow();
+
+        stubWithDefaultRequestHeaders(
+            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withBody(response)
+                    .withStatus(HttpURLConnection.HTTP_OK)));
+
+        stubWithDefaultRequestHeaders(
+            get("/persons/" + cristinPerson.getId())
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withBody(response)
+                    .withStatus(HttpURLConnection.HTTP_OK)));
+    }
+
+    void createPostPersonStub(CristinPerson cristinPerson) {
+        var response = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinPerson))
+            .orElseThrow();
+
+        stubWithDefaultRequestHeaders(
+            post(PERSONS)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withBody(response)
+                    .withStatus(HttpURLConnection.HTTP_OK)));
+    }
+
+    void createStubForInstitution(String institutionIdentifier) {
+        var institutionUnitIdentifier = institutionIdentifier + ".0.0.0";
+        var urlForUnit = generateUnitUrl(institutionUnitIdentifier);
+        var correspondingUnit = new CristinInstitutionUnit(institutionUnitIdentifier, urlForUnit);
+        var cristinInstitution = new CristinInstitution(correspondingUnit);
+
+        var response = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinInstitution))
+            .orElseThrow();
+
+        stubWithDefaultRequestHeaders(
+            get(INSTITUTIONS + institutionIdentifier)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withBody(response)
+                    .withStatus(HttpURLConnection.HTTP_OK)));
+    }
+
+    void createStubForRedirectingInstitution(String originalInstitutionId,
+                                             String redirectedInstitutionId) {
+        stubWithDefaultRequestHeaders(
+            get(INSTITUTIONS + originalInstitutionId)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_MOVED_TEMP)
+                    .withHeader("Location", INSTITUTIONS + redirectedInstitutionId)));
+    }
+
+    void createPersonNotFoundStub(String nin) {
+        stubWithDefaultRequestHeaders(
+            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_NOT_FOUND)));
+    }
+
+    void createServerErrorStub(String nin) {
+        stubWithDefaultRequestHeaders(
+            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_INTERNAL_ERROR)));
+    }
+
+    void createPersonAlreadyExistsStub() {
+        var errorBody = """
+            {
+                "status" : 400,
+                "response_id" : "test123",
+                 "errors" : [ "Norwegian national id already exists." ]
+             }
+            """;
+        stubWithDefaultRequestHeaders(
+            post(PERSONS)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_BAD_REQUEST)
+                    .withBody(errorBody)));
+    }
+
+    void createPersonConflictStub() {
+        var errorBody = """
+            {
+                "status" : 409,
+                "response_id" : "test456",
+                "errors" : [ "Conflict: Person already exists." ]
+            }
+            """;
+        stubWithDefaultRequestHeaders(
+            post(PERSONS)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_CONFLICT)
+                    .withBody(errorBody)));
+    }
+
+    String generateUnitUrl(String identifier) {
+        return UriWrapper.fromUri(cristinBaseUri).addChild("units", identifier).getUri().toString();
+    }
+
+    String generateInstitutionUrl(String identifier) {
+        return UriWrapper.fromUri(cristinBaseUri).addChild("institutions", identifier).getUri().toString();
+    }
+
+    private void stubWithDefaultRequestHeaders(MappingBuilder mappingBuilder) {
+        defaultRequestHeaders.stream()
+            .forEach(entry -> mappingBuilder.withHeader(entry.getKey(), equalTo(entry.getValue())));
+
+        stubFor(mappingBuilder);
+    }
+}

--- a/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/MockPersonRegistry.java
+++ b/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/MockPersonRegistry.java
@@ -33,6 +33,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.useraccessservice.userceation.testing.cristin.RandomNin.randomNin;
 import static nva.commons.core.attempt.Try.attempt;
 
+@SuppressWarnings("PMD.GodClass")
 public class MockPersonRegistry {
 
     private static final boolean ACTIVE = true;
@@ -136,7 +137,7 @@ public class MockPersonRegistry {
     }
 
     private void createStubForInstitution(String institutionIdentifier) {
-        var institutionUnitIdentifier = randomString();
+        var institutionUnitIdentifier = institutionIdentifier + ".0.0.0";
         var urlForUnit = generateUnitUrl(institutionUnitIdentifier);
         var correspondingUnit = new CristinInstitutionUnit(institutionUnitIdentifier, urlForUnit);
         var cristinInstitution = new CristinInstitution(correspondingUnit);
@@ -386,6 +387,42 @@ public class MockPersonRegistry {
                 .willReturn(aResponse()
                     .withStatus(HttpURLConnection.HTTP_CONFLICT)
                     .withBody(errorBody)));
+    }
+
+    public MockedPersonData personWithActiveAffiliationAtRedirectingInstitution() {
+        var nin = randomNin();
+        var cristinId = randomString();
+        var originalInstitutionId = randomString();
+        var redirectedCorrespondingUnitId = randomString();
+
+        var institution = new CristinAffiliationInstitution(originalInstitutionId,
+            generateInstitutionUrl(originalInstitutionId));
+        var unit = createAffiliationUnit();
+        var affiliation = new CristinAffiliation(institution, unit, ACTIVE);
+
+        var person = new CristinPerson(cristinId, randomString(), randomString(), List.of(affiliation), null);
+
+        if (nonNull(nin)) {
+            ninToPeople.put(nin, person);
+        }
+        cristinIdToPeople.put(person.getId(), person);
+        createStubsForPerson(nin, person);
+        createStubForRedirectingInstitution(originalInstitutionId, redirectedCorrespondingUnitId);
+
+        return new MockedPersonData(nin, cristinId);
+    }
+
+    private void createStubForRedirectingInstitution(String originalInstitutionId,
+                                                      String redirectedInstitutionId) {
+        this.cristinInstitutionIdToUnitUriMap.put(originalInstitutionId,
+            nvaScopedOrganizationCristinId(redirectedInstitutionId));
+
+        stubWithDefaultRequestHeadersEqualToFor(
+            get("/institutions/" + originalInstitutionId)
+                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
+                .willReturn(aResponse()
+                    .withStatus(HttpURLConnection.HTTP_MOVED_TEMP)
+                    .withHeader("Location", "/institutions/" + redirectedInstitutionId)));
     }
 
     public Set<URI> getUnitCristinUris(String nin) {

--- a/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/MockPersonRegistry.java
+++ b/user-creation-testing/src/main/java/no/unit/nva/useraccessservice/userceation/testing/cristin/MockPersonRegistry.java
@@ -1,18 +1,13 @@
 package no.unit.nva.useraccessservice.userceation.testing.cristin;
 
-import com.github.tomakehurst.wiremock.client.MappingBuilder;
-import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.useraccessservice.constants.ServiceConstants;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.HttpHeaders;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinAffiliation;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinAffiliationInstitution;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinAffiliationUnit;
-import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinInstitution;
-import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinInstitutionUnit;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.model.CristinPerson;
 import nva.commons.core.paths.UriWrapper;
 
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Collections;
@@ -23,17 +18,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.useraccessservice.userceation.testing.cristin.RandomNin.randomNin;
-import static nva.commons.core.attempt.Try.attempt;
 
-@SuppressWarnings("PMD.GodClass")
 public class MockPersonRegistry {
 
     private static final boolean ACTIVE = true;
@@ -42,14 +30,10 @@ public class MockPersonRegistry {
     private static final String CRISTIN_PATH = "cristin";
     private static final String PERSON_PATH = "person";
     private static final String ORGANIZATION_PATH = "organization";
-    private static final String AUTHORIZATION_HEADER_NAME = "authorization";
-    private static final String PERSONS_RESOLVE_BY_NATIONAL_ID = "/persons/resolve?national_id=%s";
     private final Map<String, CristinPerson> ninToPeople;
     private final Map<String, CristinPerson> cristinIdToPeople;
     private final Map<String, URI> cristinInstitutionIdToUnitUriMap;
-    private final String basicAuthorizationHeaderValue;
-    private final HttpHeaders defaultRequestHeaders;
-    private URI cristinBaseUri;
+    private final CristinWireMockStubs wireMockStubs;
 
     public MockPersonRegistry(String username,
                               String password,
@@ -58,148 +42,37 @@ public class MockPersonRegistry {
         this.ninToPeople = new ConcurrentHashMap<>();
         this.cristinIdToPeople = new ConcurrentHashMap<>();
         this.cristinInstitutionIdToUnitUriMap = new ConcurrentHashMap<>();
-        this.cristinBaseUri = cristinBaseUri;
-        this.basicAuthorizationHeaderValue = generateBasicAuthorizationHeaderValue(username, password);
-        this.defaultRequestHeaders = defaultRequestHeaders;
-    }
-
-    private String generateBasicAuthorizationHeaderValue(String username, String password) {
-        var toBeEncoded = (username + ":" + password).getBytes();
-        return "Basic " + Base64.getEncoder().encodeToString(toBeEncoded);
+        var basicAuthorizationHeaderValue = generateBasicAuthorizationHeaderValue(username, password);
+        this.wireMockStubs = new CristinWireMockStubs(basicAuthorizationHeaderValue, cristinBaseUri,
+            defaultRequestHeaders);
     }
 
     public MockedPersonData mockResponseForBadGateway() {
         var nin = randomNin();
         var cristinId = randomString();
-        createPersonSearchStubBadGateway(nin);
+        wireMockStubs.createPersonSearchStubBadGateway(nin);
         return new MockedPersonData(nin, cristinId);
-    }
-
-    private void createPersonSearchStubBadGateway(String nin) {
-        stubWithDefaultRequestHeadersEqualToFor(
-            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_BAD_GATEWAY)));
-    }
-
-    private void stubWithDefaultRequestHeadersEqualToFor(MappingBuilder mappingBuilder) {
-        defaultRequestHeaders.stream()
-            .forEach(entry -> mappingBuilder.withHeader(entry.getKey(), equalTo(entry.getValue())));
-
-        stubFor(mappingBuilder);
     }
 
     public MockedPersonData mockResponseForIllegalJson() {
         var nin = randomNin();
         var cristinId = randomString();
-        createPersonSearchStubIllegalJson(nin);
+        wireMockStubs.createPersonSearchStubIllegalJson(nin);
         return new MockedPersonData(nin, cristinId);
-    }
-
-    private void createPersonSearchStubIllegalJson(String nin) {
-        var illegalBodyAsObjectIsExpected = "[]";
-
-        stubWithDefaultRequestHeadersEqualToFor(
-            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withBody(illegalBodyAsObjectIsExpected)
-                    .withStatus(HttpURLConnection.HTTP_OK)));
     }
 
     public MockedPersonData personWithoutAffiliations() {
         var nin = randomNin();
         var cristinId = randomString();
 
-
         createPersonWithoutAffiliations(nin, cristinId);
 
         return new MockedPersonData(nin, cristinId);
     }
 
-    private void createPersonWithoutAffiliations(String nin, String cristinId) {
-
-        var person = new CristinPerson(cristinId, randomString(), randomString(), null, null);
-        var institutions = Collections.<String>emptyList();
-        updateBuffersAndStubs(nin, person, institutions);
-    }
-
-    private void updateBuffersAndStubs(String nin,
-                                       CristinPerson cristinPerson,
-                                       List<String> institutionIds) {
-        if (nonNull(nin)) {
-            ninToPeople.put(nin, cristinPerson);
-        }
-        cristinIdToPeople.put(cristinPerson.getId(), cristinPerson);
-        createStubsForPerson(nin, cristinPerson);
-        institutionIds.forEach(this::createStubForInstitution);
-    }
-
-    private void createStubForInstitution(String institutionIdentifier) {
-        var institutionUnitIdentifier = institutionIdentifier + ".0.0.0";
-        var urlForUnit = generateUnitUrl(institutionUnitIdentifier);
-        var correspondingUnit = new CristinInstitutionUnit(institutionUnitIdentifier, urlForUnit);
-        var cristinInstitution = new CristinInstitution(correspondingUnit);
-
-        this.cristinInstitutionIdToUnitUriMap.put(institutionIdentifier,
-            nvaScopedOrganizationCristinId(institutionUnitIdentifier));
-
-        var response
-            = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinInstitution))
-            .orElseThrow();
-
-        stubWithDefaultRequestHeadersEqualToFor(
-            get("/institutions/" + institutionIdentifier)
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withBody(response)
-                    .withStatus(HttpURLConnection.HTTP_OK)));
-    }
-
-    private String generateUnitUrl(String identifier) {
-        return UriWrapper.fromUri(cristinBaseUri).addChild("units", identifier).getUri().toString();
-    }
-
-    private URI nvaScopedOrganizationCristinId(String identifier) {
-        return new UriWrapper(HTTPS_SCHEME, ServiceConstants.API_DOMAIN)
-            .addChild(CRISTIN_PATH, ORGANIZATION_PATH, identifier)
-            .getUri();
-    }
-
-    private void createStubsForPerson(String nin, CristinPerson cristinPerson) {
-        var response
-            = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinPerson))
-            .orElseThrow();
-
-        stubWithDefaultRequestHeadersEqualToFor(
-            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withBody(response)
-                    .withStatus(HttpURLConnection.HTTP_OK)));
-        
-        stubWithDefaultRequestHeadersEqualToFor(
-            get("/persons/" + cristinPerson.getId())
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withBody(response)
-                    .withStatus(HttpURLConnection.HTTP_OK)));
-    }
-
     public void createPostPersonStub(CristinPerson cristinPerson) {
-        var response
-            = attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(cristinPerson))
-                  .orElseThrow();
-
-        stubWithDefaultRequestHeadersEqualToFor(
-            post("/persons")
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                                .withBody(response)
-                                .withStatus(HttpURLConnection.HTTP_OK)));
+        wireMockStubs.createPostPersonStub(cristinPerson);
     }
-
 
     public MockedPersonData personWithExactlyOneActiveEmployment() {
         var nin = randomNin();
@@ -210,40 +83,6 @@ public class MockPersonRegistry {
         createPersonWithAffiliations(nin, cristinId, affiliations);
 
         return new MockedPersonData(nin, cristinId);
-    }
-
-    private CristinAffiliation createCristinAffiliation(boolean active) {
-        var institution = createAffiliationInstitution();
-        var unit = createAffiliationUnit();
-
-        return new CristinAffiliation(institution, unit, active);
-    }
-
-    private CristinAffiliationInstitution createAffiliationInstitution() {
-        var identifier = randomString();
-        return new CristinAffiliationInstitution(identifier, generateInstitutionUrl(identifier));
-    }
-
-    private String generateInstitutionUrl(String identifier) {
-        return UriWrapper.fromUri(cristinBaseUri).addChild("institutions", identifier).getUri().toString();
-    }
-
-    private CristinAffiliationUnit createAffiliationUnit() {
-        var identifier = randomString();
-        return new CristinAffiliationUnit(identifier, generateUnitUrl(identifier));
-    }
-
-    private void createPersonWithAffiliations(String nin,
-                                              String cristinId,
-                                              List<CristinAffiliation> cristinAffiliations) {
-        var person = new CristinPerson(cristinId, randomString(), randomString(), cristinAffiliations, null);
-
-        var institutions = cristinAffiliations.stream()
-            .map(CristinAffiliation::getInstitution)
-            .map(CristinAffiliationInstitution::getId)
-            .collect(Collectors.toList());
-
-        updateBuffersAndStubs(nin, person, institutions);
     }
 
     public MockedPersonData personWithExactlyOneInactiveEmployment() {
@@ -314,7 +153,7 @@ public class MockPersonRegistry {
     }
 
     public void setCristinBaseUri(URI cristinBaseUri) {
-        this.cristinBaseUri = cristinBaseUri;
+        wireMockStubs.setCristinBaseUri(cristinBaseUri);
     }
 
     public URI getCristinIdForPerson(String nin) {
@@ -326,67 +165,23 @@ public class MockPersonRegistry {
         return ninToPeople.get(nin);
     }
 
-    private URI nvaScopedPersonCristinId(String identifier) {
-        return new UriWrapper(HTTPS_SCHEME, ServiceConstants.API_DOMAIN)
-            .addChild(CRISTIN_PATH, PERSON_PATH, identifier)
-            .getUri();
-    }
-
-    private CristinAffiliation createCristinAffiliation(CristinAffiliationInstitution institution, boolean active) {
-        var unit = createAffiliationUnit();
-
-        return new CristinAffiliation(institution, unit, active);
-    }
-
     public MockedPersonData mockResponseForPersonNotFound() {
         var nin = randomNin();
         var cristinId = randomString();
-        stubWithDefaultRequestHeadersEqualToFor(
-            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_NOT_FOUND)));
+        wireMockStubs.createPersonNotFoundStub(nin);
         return new MockedPersonData(nin, cristinId);
     }
-    
+
     public void setupServerErrorForNin(String nin) {
-        stubWithDefaultRequestHeadersEqualToFor(
-            get(PERSONS_RESOLVE_BY_NATIONAL_ID.formatted(nin))
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_INTERNAL_ERROR)));
+        wireMockStubs.createServerErrorStub(nin);
     }
-    
+
     public void setupCreatePersonAlreadyExistsError() {
-        var errorBody = """
-            {
-                "status" : 400,
-                "response_id" : "test123",
-                 "errors" : [ "Norwegian national id already exists." ]
-             }
-            """;
-        stubWithDefaultRequestHeadersEqualToFor(
-            post("/persons")
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                                .withStatus(HttpURLConnection.HTTP_BAD_REQUEST)
-                                .withBody(errorBody)));
+        wireMockStubs.createPersonAlreadyExistsStub();
     }
 
     public void setupCreatePersonConflictError() {
-        var errorBody = """
-            {
-                "status" : 409,
-                "response_id" : "test456",
-                "errors" : [ "Conflict: Person already exists." ]
-            }
-            """;
-        stubWithDefaultRequestHeadersEqualToFor(
-            post("/persons")
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_CONFLICT)
-                    .withBody(errorBody)));
+        wireMockStubs.createPersonConflictStub();
     }
 
     public MockedPersonData personWithActiveAffiliationAtRedirectingInstitution() {
@@ -396,37 +191,105 @@ public class MockPersonRegistry {
         var redirectedCorrespondingUnitId = randomString();
 
         var institution = new CristinAffiliationInstitution(originalInstitutionId,
-            generateInstitutionUrl(originalInstitutionId));
+            wireMockStubs.generateInstitutionUrl(originalInstitutionId));
         var unit = createAffiliationUnit();
         var affiliation = new CristinAffiliation(institution, unit, ACTIVE);
 
         var person = new CristinPerson(cristinId, randomString(), randomString(), List.of(affiliation), null);
 
-        if (nonNull(nin)) {
-            ninToPeople.put(nin, person);
-        }
+        ninToPeople.put(nin, person);
         cristinIdToPeople.put(person.getId(), person);
-        createStubsForPerson(nin, person);
-        createStubForRedirectingInstitution(originalInstitutionId, redirectedCorrespondingUnitId);
+        wireMockStubs.createStubsForPerson(nin, person);
+        wireMockStubs.createStubForRedirectingInstitution(originalInstitutionId, redirectedCorrespondingUnitId);
 
         return new MockedPersonData(nin, cristinId);
     }
 
-    private void createStubForRedirectingInstitution(String originalInstitutionId,
-                                                      String redirectedInstitutionId) {
-        this.cristinInstitutionIdToUnitUriMap.put(originalInstitutionId,
-            nvaScopedOrganizationCristinId(redirectedInstitutionId));
-
-        stubWithDefaultRequestHeadersEqualToFor(
-            get("/institutions/" + originalInstitutionId)
-                .withHeader(AUTHORIZATION_HEADER_NAME, equalTo(basicAuthorizationHeaderValue))
-                .willReturn(aResponse()
-                    .withStatus(HttpURLConnection.HTTP_MOVED_TEMP)
-                    .withHeader("Location", "/institutions/" + redirectedInstitutionId)));
-    }
-
     public Set<URI> getUnitCristinUris(String nin) {
         return getUnitCristinUris(nin, allAffiliations());
+    }
+
+    public Set<URI> getInstitutionUnitCristinUris(String nin) {
+        return getInstitutionUnitCristinUris(nin, allAffiliations());
+    }
+
+    public Set<URI> getInstitutionUnitCristinUrisByState(String nin, boolean active) {
+        return getInstitutionUnitCristinUris(nin, affiliationsByState(active));
+    }
+
+    private static String generateBasicAuthorizationHeaderValue(String username, String password) {
+        var toBeEncoded = (username + ":" + password).getBytes();
+        return "Basic " + Base64.getEncoder().encodeToString(toBeEncoded);
+    }
+
+    private void createPersonWithoutAffiliations(String nin, String cristinId) {
+        var person = new CristinPerson(cristinId, randomString(), randomString(), null, null);
+        var institutions = Collections.<String>emptyList();
+        updateBuffersAndStubs(nin, person, institutions);
+    }
+
+    private void updateBuffersAndStubs(String nin,
+                                       CristinPerson cristinPerson,
+                                       List<String> institutionIds) {
+        if (nonNull(nin)) {
+            ninToPeople.put(nin, cristinPerson);
+        }
+        cristinIdToPeople.put(cristinPerson.getId(), cristinPerson);
+        wireMockStubs.createStubsForPerson(nin, cristinPerson);
+        institutionIds.forEach(this::createStubForInstitution);
+    }
+
+    private void createStubForInstitution(String institutionIdentifier) {
+        var institutionUnitIdentifier = institutionIdentifier + ".0.0.0";
+        this.cristinInstitutionIdToUnitUriMap.put(institutionIdentifier,
+            nvaScopedOrganizationCristinId(institutionUnitIdentifier));
+        wireMockStubs.createStubForInstitution(institutionIdentifier);
+    }
+
+    private URI nvaScopedOrganizationCristinId(String identifier) {
+        return new UriWrapper(HTTPS_SCHEME, ServiceConstants.API_DOMAIN)
+            .addChild(CRISTIN_PATH, ORGANIZATION_PATH, identifier)
+            .getUri();
+    }
+
+    private URI nvaScopedPersonCristinId(String identifier) {
+        return new UriWrapper(HTTPS_SCHEME, ServiceConstants.API_DOMAIN)
+            .addChild(CRISTIN_PATH, PERSON_PATH, identifier)
+            .getUri();
+    }
+
+    private CristinAffiliation createCristinAffiliation(boolean active) {
+        var institution = createAffiliationInstitution();
+        var unit = createAffiliationUnit();
+        return new CristinAffiliation(institution, unit, active);
+    }
+
+    private CristinAffiliation createCristinAffiliation(CristinAffiliationInstitution institution, boolean active) {
+        var unit = createAffiliationUnit();
+        return new CristinAffiliation(institution, unit, active);
+    }
+
+    private CristinAffiliationInstitution createAffiliationInstitution() {
+        var identifier = randomString();
+        return new CristinAffiliationInstitution(identifier, wireMockStubs.generateInstitutionUrl(identifier));
+    }
+
+    private CristinAffiliationUnit createAffiliationUnit() {
+        var identifier = randomString();
+        return new CristinAffiliationUnit(identifier, wireMockStubs.generateUnitUrl(identifier));
+    }
+
+    private void createPersonWithAffiliations(String nin,
+                                              String cristinId,
+                                              List<CristinAffiliation> cristinAffiliations) {
+        var person = new CristinPerson(cristinId, randomString(), randomString(), cristinAffiliations, null);
+
+        var institutions = cristinAffiliations.stream()
+            .map(CristinAffiliation::getInstitution)
+            .map(CristinAffiliationInstitution::getId)
+            .toList();
+
+        updateBuffersAndStubs(nin, person, institutions);
     }
 
     private Set<URI> getUnitCristinUris(String nin, Predicate<CristinAffiliation> predicate) {
@@ -440,14 +303,6 @@ public class MockPersonRegistry {
             .collect(Collectors.toSet());
     }
 
-    private Predicate<CristinAffiliation> allAffiliations() {
-        return cristinAffiliation -> true;
-    }
-
-    public Set<URI> getInstitutionUnitCristinUris(String nin) {
-        return getInstitutionUnitCristinUris(nin, allAffiliations());
-    }
-
     private Set<URI> getInstitutionUnitCristinUris(String nin, Predicate<CristinAffiliation> predicate) {
         var person = getPerson(nin);
         return person.getAffiliations().stream()
@@ -459,8 +314,8 @@ public class MockPersonRegistry {
             .collect(Collectors.toSet());
     }
 
-    public Set<URI> getInstitutionUnitCristinUrisByState(String nin, boolean active) {
-        return getInstitutionUnitCristinUris(nin, affiliationsByState(active));
+    private Predicate<CristinAffiliation> allAffiliations() {
+        return cristinAffiliation -> true;
     }
 
     private Predicate<CristinAffiliation> affiliationsByState(boolean active) {

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/IdentityServiceErrorCodes.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/IdentityServiceErrorCodes.java
@@ -92,6 +92,13 @@ public final class IdentityServiceErrorCodes {
      */
     public static final ServiceErrorCode PERSON_CREATION_FAILED = new ServiceErrorCode(3003, HTTP_BAD_GATEWAY);
 
+    /**
+     * 3004: Upstream redirect detected.
+     * Used when an upstream service responds with a redirect (3xx),
+     * indicating a discontinued or moved resource.
+     */
+    public static final ServiceErrorCode UPSTREAM_REDIRECT = new ServiceErrorCode(3004, HTTP_BAD_GATEWAY);
+
     private IdentityServiceErrorCodes() {
         // NO-OP
     }

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/CristinPersonRegistry.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/CristinPersonRegistry.java
@@ -202,8 +202,7 @@ public final class CristinPersonRegistry implements PersonRegistry {
         try {
             return Optional.of(executeRequest(request, CristinInstitution.class));
         } catch (IdentityServiceRedirectException e) {
-            LOGGER.warn("Institution URL {} was redirected. "
-                        + "Skipping affiliation to prevent unintended access.", institutionUri);
+            LOGGER.warn("Institution URL {} was redirected, skipping affiliation.", institutionUri);
             return Optional.empty();
         }
     }
@@ -241,7 +240,7 @@ public final class CristinPersonRegistry implements PersonRegistry {
                   .collect(Collectors.groupingBy(GenericPair::getLeft, mapping(GenericPair::getRight, toList())))
                   .entrySet().stream()
                   .map(a -> new Affiliation(a.getKey(), a.getValue()))
-                  .collect(toList());
+                  .toList();
 
         if (personAffiliations.isEmpty()) {
             LOGGER.warn("Cristin person {} has no active affiliations", cristinPerson.getId());

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/CristinPersonRegistry.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/CristinPersonRegistry.java
@@ -10,6 +10,7 @@ import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.Iden
 import no.unit.nva.useraccessservice.usercreation.person.IdentityServiceErrorCodes;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceMissingRequiredFieldsException;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceNotFoundException;
+import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceRedirectException;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceUnavailableException;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceUpstreamBodyParsingException;
 import no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions.IdentityServiceUpstreamInternalServerErrorException;
@@ -71,6 +72,7 @@ public final class CristinPersonRegistry implements PersonRegistry {
     private static final String APPLICATION_JSON = "application/json";
     private static final int ONE_HUNDRED = 100;
     private static final int SUCCESS_FAMILY = 2;
+    private static final int REDIRECT_FAMILY = 3;
     private final HttpClient httpClient;
     private final URI cristinBaseUri;
     private final String apiDomain;
@@ -95,7 +97,7 @@ public final class CristinPersonRegistry implements PersonRegistry {
                                         .withHeader(BOT_FILTER_BYPASS_HEADER_NAME, BOT_FILTER_BYPASS_HEADER_VALUE);
         return personRegistry(HttpClient.newBuilder()
                                   .version(Version.HTTP_1_1)
-                                  .followRedirects(Redirect.NORMAL)
+                                  .followRedirects(Redirect.NEVER)
                                   .build(),
                               ServiceConstants.CRISTIN_BASE_URI,
                               ServiceConstants.API_DOMAIN,
@@ -194,9 +196,16 @@ public final class CristinPersonRegistry implements PersonRegistry {
         return Optional.ofNullable(executeRequest(request, CristinPerson.class));
     }
 
-    private CristinInstitution fetchInstitutionFromCristin(URI institutionUri, CristinCredentials cristinCredentials) {
+    private Optional<CristinInstitution> fetchInstitutionFromCristin(URI institutionUri,
+                                                                      CristinCredentials cristinCredentials) {
         var request = createGetRequest(institutionUri, cristinCredentials);
-        return executeRequest(request, CristinInstitution.class);
+        try {
+            return Optional.of(executeRequest(request, CristinInstitution.class));
+        } catch (IdentityServiceRedirectException e) {
+            LOGGER.warn("Institution URL {} was redirected. "
+                        + "Skipping affiliation to prevent unintended access.", institutionUri);
+            return Optional.empty();
+        }
     }
 
     private HttpRequest createGetRequest(URI uri, CristinCredentials cristinCredentials) {
@@ -228,6 +237,7 @@ public final class CristinPersonRegistry implements PersonRegistry {
             = cristinPerson.getAffiliations().stream()
                   .filter(CristinAffiliation::isActive)
                   .map(activeAffiliation -> collectAffiliation(activeAffiliation, cristinCredentials))
+                  .flatMap(Optional::stream)
                   .collect(Collectors.groupingBy(GenericPair::getLeft, mapping(GenericPair::getRight, toList())))
                   .entrySet().stream()
                   .map(a -> new Affiliation(a.getKey(), a.getValue()))
@@ -267,14 +277,16 @@ public final class CristinPersonRegistry implements PersonRegistry {
                    .getUri();
     }
 
-    private GenericPair<URI> collectAffiliation(CristinAffiliation cristinAffiliation,
-                                                CristinCredentials cristinCredentials) {
-
+    private Optional<GenericPair<URI>> collectAffiliation(CristinAffiliation cristinAffiliation,
+                                                          CristinCredentials cristinCredentials) {
         var institutionUri = URI.create(cristinAffiliation.getInstitution().getUrl());
-        var cristinInstitution = fetchInstitutionFromCristin(institutionUri, cristinCredentials);
-        var institutionId = cristinInstitution.getCorrespondingUnit().getId();
-        return new GenericPair<>(generateCristinIdForOrganization(institutionId),
-                                 generateCristinIdForOrganization(cristinAffiliation.getUnit().getId()));
+        return fetchInstitutionFromCristin(institutionUri, cristinCredentials)
+                   .map(cristinInstitution -> {
+                       var institutionId = cristinInstitution.getCorrespondingUnit().getId();
+                       return new GenericPair<>(
+                           generateCristinIdForOrganization(institutionId),
+                           generateCristinIdForOrganization(cristinAffiliation.getUnit().getId()));
+                   });
     }
 
     private Optional<CristinPerson> fetchPersonByNinFromCristin(NationalIdentityNumber nin,
@@ -348,6 +360,10 @@ public final class CristinPersonRegistry implements PersonRegistry {
 
     private void assertSuccessResponse(HttpRequest request, HttpResponse<String> response) {
         int statusCode = response.statusCode();
+        if (statusCode / ONE_HUNDRED == REDIRECT_FAMILY) {
+            var location = response.headers().firstValue("Location").orElse("unknown");
+            throw new IdentityServiceRedirectException(request.uri(), location, statusCode);
+        }
         if (statusCode / ONE_HUNDRED != SUCCESS_FAMILY) {
             var message = generateErrorMessageForResponse(request, response);
             LOGGER.info(message);

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/exceptions/IdentityServiceRedirectException.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/exceptions/IdentityServiceRedirectException.java
@@ -1,0 +1,12 @@
+package no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions;
+
+import java.net.URI;
+
+public class IdentityServiceRedirectException extends RuntimeException {
+
+    private static final String MESSAGE_FORMAT = "Request to %s was redirected to %s (HTTP %d)";
+
+    public IdentityServiceRedirectException(URI fromUri, String toLocation, int statusCode) {
+        super(MESSAGE_FORMAT.formatted(fromUri, toLocation, statusCode));
+    }
+}

--- a/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/exceptions/IdentityServiceRedirectException.java
+++ b/user-creation/src/main/java/no/unit/nva/useraccessservice/usercreation/person/cristin/exceptions/IdentityServiceRedirectException.java
@@ -1,12 +1,14 @@
 package no.unit.nva.useraccessservice.usercreation.person.cristin.exceptions;
 
+import static no.unit.nva.useraccessservice.usercreation.person.IdentityServiceErrorCodes.UPSTREAM_REDIRECT;
+
 import java.net.URI;
 
-public class IdentityServiceRedirectException extends RuntimeException {
+public class IdentityServiceRedirectException extends IdentityServiceException {
 
     private static final String MESSAGE_FORMAT = "Request to %s was redirected to %s (HTTP %d)";
 
     public IdentityServiceRedirectException(URI fromUri, String toLocation, int statusCode) {
-        super(MESSAGE_FORMAT.formatted(fromUri, toLocation, statusCode));
+        super(UPSTREAM_REDIRECT, MESSAGE_FORMAT.formatted(fromUri, toLocation, statusCode));
     }
 }

--- a/user-creation/src/test/java/no/unit/nva/useraccessservice/usercreation/CristinPersonRegistryTest.java
+++ b/user-creation/src/test/java/no/unit/nva/useraccessservice/usercreation/CristinPersonRegistryTest.java
@@ -171,6 +171,16 @@ class CristinPersonRegistryTest {
     }
 
     @Test
+    void shouldExcludeAffiliationWhenInstitutionResolvesToDifferentOrganization() {
+        var person = mockPersonRegistry.personWithActiveAffiliationAtRedirectingInstitution();
+        var nin = NationalIdentityNumber.fromString(person.nin());
+
+        var fetchedPerson = personRegistry.fetchPersonByNin(nin);
+        assertThat(fetchedPerson.isPresent(), is(equalTo(true)));
+        assertThat(fetchedPerson.get().getAffiliations(), emptyIterable());
+    }
+
+    @Test
     void shouldReturnEmptyListOfAffiliationsIfFieldIsMissingInCristinOnGetPerson() {
         var personNin = scenarios.personWithoutAffiliations().nin();
         var nin = NationalIdentityNumber.fromString(personNin);


### PR DESCRIPTION
## Summary

- Cristin API redirects discontinued institution URLs (e.g., 1937 → 2037), causing users with ended employment to still appear as affiliated with the redirected institution
- Changed HttpClient to `Redirect.NEVER` and added redirect detection in `assertSuccessResponse`
- When a redirect is detected during institution lookup, the affiliation is skipped and a warning is logged
- Added `IdentityServiceRedirectException` for redirect signal handling

https://sikt.atlassian.net/browse/NP-51008