### PR TITLE
fix(template): remove API Gateway cache on single customer lookup

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -930,14 +930,17 @@ Resources:
           ResourcePath: '/~1'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
+          RequireAuthorizationForCacheControl: false
         - HttpMethod: 'GET'
           ResourcePath: '/~1{identifier}'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
+          RequireAuthorizationForCacheControl: false
         - HttpMethod: 'GET'
           ResourcePath: '/~1cristinId~1{cristinId}'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
+          RequireAuthorizationForCacheControl: false
       AccessLogSetting:
         DestinationArn: !GetAtt ApiAccessLogGroup.Arn
         Format: !Join

--- a/template.yaml
+++ b/template.yaml
@@ -129,7 +129,7 @@ Globals:
   Api:
     Cors:
       AllowMethods: '''POST, PUT, GET, OPTIONS, DELETE'''
-      AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
+      AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Cache-Control'''
       AllowOrigin: '''*'''
     OpenApiVersion: 3.0.1
 

--- a/template.yaml
+++ b/template.yaml
@@ -931,6 +931,10 @@ Resources:
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
         - HttpMethod: 'GET'
+          ResourcePath: '/~1{identifier}'
+          CacheTtlInSeconds: !Ref CacheTtlInSeconds
+          CachingEnabled: false
+        - HttpMethod: 'GET'
           ResourcePath: '/~1cristinId~1{cristinId}'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true

--- a/template.yaml
+++ b/template.yaml
@@ -129,7 +129,7 @@ Globals:
   Api:
     Cors:
       AllowMethods: '''POST, PUT, GET, OPTIONS, DELETE'''
-      AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,Cache-Control'''
+      AllowHeaders: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
       AllowOrigin: '''*'''
     OpenApiVersion: 3.0.1
 
@@ -930,17 +930,10 @@ Resources:
           ResourcePath: '/~1'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
-          RequireAuthorizationForCacheControl: false
-        - HttpMethod: 'GET'
-          ResourcePath: '/~1{identifier}'
-          CacheTtlInSeconds: !Ref CacheTtlInSeconds
-          CachingEnabled: true
-          RequireAuthorizationForCacheControl: false
         - HttpMethod: 'GET'
           ResourcePath: '/~1cristinId~1{cristinId}'
           CacheTtlInSeconds: !Ref CacheTtlInSeconds
           CachingEnabled: true
-          RequireAuthorizationForCacheControl: false
       AccessLogSetting:
         DestinationArn: !GetAtt ApiAccessLogGroup.Arn
         Format: !Join


### PR DESCRIPTION
## Summary

- Removed API Gateway caching from `GET /{identifier}` endpoint to prevent stale data after customer updates
- Caching remains on `GET /` (list) and `GET /cristinId/{cristinId}` which are less affected by write-then-read patterns

The API Gateway cache (introduced in #486) served stale data for up to 5 minutes after a PUT to `/customer/{id}`. CloudFormation does not support `RequireAuthorizationForCacheControl` on MethodSettings, so cache invalidation via headers is not possible through SAM/CFN. Removing caching on the single-item lookup is the simplest fix.

https://sikt.atlassian.net/browse/NP-51023